### PR TITLE
[math] Replace spatial_dim in `native_call()`

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [push]
+on: [push, workflow_dispatch]
 
 jobs:
   build:


### PR DESCRIPTION
Currently the function `f` in `native_call()` must return a tensor with 
the same dimension layout as the `inputs`. This `f` is often a neural 
network. However, in operations such as lifting the dimension from 2D 
observables to 3D geometries, the spatial dimensions will differ. This 
PR enables the support of different output spatial dimensions.