### PR TITLE
Higher-order differentiation schemes (periodic only)

### DIFF
--- a/phi/field/_field.py
+++ b/phi/field/_field.py
@@ -78,7 +78,7 @@ class Field:
             keep_extrapolation: Only available if `self` is a `SampledField`.
                 If True, the resampled field will inherit the extrapolation from `self` instead of `representation`.
                 This can result in non-compatible value tensors for staggered grids where the tensor size depends on the extrapolation type.
-            scheme: Numerical scheme for resampling.
+            scheme: Numerical scheme for resampling. See `reduce_sample`
 
         Returns:
             Field object of same type as `representation`
@@ -358,7 +358,8 @@ def reduce_sample(field: Field, geometry: Geometry, dim=channel('vector'), schem
         field: Source `Field` to sample.
         geometry: Single or batched `phi.geom.Geometry`.
         dim: Dimension of result, resulting from reduction of channel dimensions.
-        scheme: Numerical scheme.
+        scheme: Numerical scheme. By default linear interpolation is used
+            supported: implicit 6th oder (only for sampling at mid-points, sampling at other locations and unsupported schemes result in automatic fallback to linear interpolation)
 
     Returns:
         Sampled values as a `phi.math.Tensor`

--- a/phi/field/_field_math.py
+++ b/phi/field/_field_math.py
@@ -49,6 +49,7 @@ def laplace(field: GridType, axes=spatial, scheme: Scheme = Scheme(2)) -> GridTy
         field: n-dimensional `CenteredGrid`
         axes: The second derivative along these dimensions is summed over
         scheme: finite difference `Scheme` used for differentiation
+            supported: explicit 2/4th order - implicit 6th order
 
     Returns:
         laplacian field as `CenteredGrid`
@@ -120,6 +121,7 @@ def spatial_gradient(field: CenteredGrid,
         stack_dim: Dimension to be added. This dimension lists the spatial_gradient w.r.t. the spatial dimensions.
             The `field` must not have a dimension of the same name.
         scheme: finite difference `Scheme` used for differentiation
+            supported: explicit 2/4th order - implicit 6th order
 
     Returns:
         spatial_gradient field of type `type`.
@@ -308,6 +310,7 @@ def divergence(field: Grid, scheme: Scheme = Scheme(2)) -> CenteredGrid:
     Args:
         field: vector field as `CenteredGrid` or `StaggeredGrid`
         scheme: finite difference `Scheme` used for differentiation
+            supported: explicit 2/4th order - implicit 6th order
 
     Returns:
         Divergence field as `CenteredGrid`

--- a/phi/field/_field_math.py
+++ b/phi/field/_field_math.py
@@ -1,15 +1,17 @@
+from functools import partial
 from numbers import Number
 from typing import Callable, List, Tuple
 
 from phi import geom
 from phi import math
 from phi.geom import Box, Geometry, Sphere, Cuboid
-from phi.math import Tensor, spatial, instance, tensor, masked_fill, channel, Shape, batch, unstack, wrap, vec
+from phi.math import Tensor, spatial, instance, tensor, masked_fill, channel, Shape, batch, unstack, wrap, vec, \
+    rename_dims, solve_linear, jit_compile_linear
 from ._field import Field, SampledField, SampledFieldType, as_extrapolation
 from ._grid import CenteredGrid, Grid, StaggeredGrid, GridType
 from ._point_cloud import PointCloud
 from .numerical import Scheme
-from ..math.extrapolation import Extrapolation
+from ..math.extrapolation import Extrapolation, SYMMETRIC, REFLECT, ANTIREFLECT, ANTISYMMETRIC, combine_by_direction, map
 
 
 def bake_extrapolation(grid: GridType) -> GridType:
@@ -38,16 +40,71 @@ def bake_extrapolation(grid: GridType) -> GridType:
         raise ValueError(f"Not a valid grid: {grid}")
 
 
-def laplace(field: GridType, axes=spatial) -> GridType:
-    """ Finite-difference laplace operator for Grids. See `phi.math.laplace()`. """
-    result = field._op1(lambda tensor: math.laplace(tensor, dx=field.dx, padding=field.extrapolation, dims=axes))
+def laplace(field: GridType, axes=spatial, scheme: Scheme = Scheme(2)) -> GridType:
+    """
+    Spatial Laplace operator for scalar grid.
+    If a vector grid is passed, it is assumed to be centered and the laplace is computed component-wise.
+
+    Args:
+        field: n-dimensional `CenteredGrid`
+        axes: The second derivative along these dimensions is summed over
+        scheme: finite difference `Scheme` used for differentiation
+
+    Returns:
+        laplacian field as `CenteredGrid`
+    """
+
+    axes_names = field.shape.only(axes).names
+    extrapol_map = {}
+    if not scheme.is_implicit:
+        if scheme.order == 2:
+                values, needed_shifts = [1, -2, 1], (-1, 0, 1)
+
+        elif scheme.order == 4:
+                values, needed_shifts = [-1/12, 4/3, -5/2, 4/3, -1/12], (-2, -1, 0, 1, 2)
+
+    else:
+        extrapol_map_rhs = {}
+        if scheme.order == 6:
+            values, needed_shifts = [3/44, 12/11, -51/22, 12/11, 3/44], (-2, -1, 0, 1, 2)
+            extrapol_map['symmetric'] = combine_by_direction(REFLECT, SYMMETRIC)
+
+            values_rhs, needed_shifts_rhs = [2/11, 1, 2/11], (-1, 0, 1)
+            extrapol_map_rhs['symmetric'] = combine_by_direction(REFLECT, SYMMETRIC)
+
+    base_widths = (abs(min(needed_shifts)), max(needed_shifts))
+    field.with_extrapolation(map(_ex_map_f(extrapol_map), field.extrapolation))
+
+    padded_components = [pad(field, {dim: base_widths}) for dim in axes_names]
+
+    shifted_components = [shift(padded_component, needed_shifts, None, pad=False, dims=dim) for padded_component, dim in zip(padded_components, axes_names)]
+    result_components = [sum([value * shift for value, shift in zip(values, shifted_component)]) / field.dx.vector[dim]**2 for shifted_component, dim in zip(shifted_components, axes_names)]
+
+
+    if scheme.is_implicit:
+        result_components = stack(result_components, channel('laplacian'))
+        result_components.with_values(result_components.values._cache())
+        result_components = result_components.with_extrapolation(map(_ex_map_f(extrapol_map_rhs), field.extrapolation))
+        scheme.solve.x0 = result_components
+        result_components = solve_linear(_lhs_for_implicit_scheme, result_components, solve=scheme.solve,
+                                         f_kwargs={"values_rhs": values_rhs, "needed_shifts_rhs": needed_shifts_rhs,
+                                        "stack_dim": channel('laplacian')})
+        result_components = unstack(result_components, 'laplacian')
+        extrapol_map = extrapol_map_rhs
+
+    result_components = [component.with_bounds(field.bounds) for component in result_components]
+    result = sum(result_components)
+    result = result.with_extrapolation(map(_ex_map_f(extrapol_map), field.extrapolation))
+
     return result
 
 
-def spatial_gradient(field: Field,
-                     extrapolation: Extrapolation = None,
+def spatial_gradient(field: CenteredGrid,
+                     gradient_extrapolation: Extrapolation = None,
                      type: type = CenteredGrid,
-                     stack_dim: Shape = channel('vector')):
+                     stack_dim: Shape = channel('vector'),
+                     scheme: Scheme = Scheme(2)):
+
     """
     Finite difference spatial_gradient.
 
@@ -58,27 +115,114 @@ def spatial_gradient(field: Field,
 
     Args:
         field: centered grid of any number of dimensions (scalar field, vector field, tensor field)
+        gradient_extrapolation: Extrapolation of the output
         type: either `CenteredGrid` or `StaggeredGrid`
         stack_dim: Dimension to be added. This dimension lists the spatial_gradient w.r.t. the spatial dimensions.
             The `field` must not have a dimension of the same name.
+        scheme: finite difference `Scheme` used for differentiation
 
     Returns:
         spatial_gradient field of type `type`.
 
     """
-    assert isinstance(field, Grid)
-    if extrapolation is None:
-        extrapolation = field.extrapolation.spatial_gradient()
+
+    if gradient_extrapolation == None:
+        gradient_extrapolation = field.extrapolation
+
+    extrapol_map = {}
+    if not scheme.is_implicit:
+        if scheme.order == 2:
+            if type == CenteredGrid:
+                values, needed_shifts = [-1/2, 1/2], (-1, 1)
+            else:
+                values, needed_shifts = [-1, 1], (0, 1)
+
+        elif scheme.order == 4:
+            if type == CenteredGrid:
+                values, needed_shifts = [1/12, -2/3, 2/3, -1/12], (-2, -1, 1, 2)
+            else:
+                values, needed_shifts = [1/24, -27/24, 27/24, -1/24], (-1, 0, 1, 2)
+    else:
+        extrapol_map_rhs = {}
+        if scheme.order == 6:
+            if type == CenteredGrid:
+                values, needed_shifts = [-1/36, -14/18, 14/18, 1/36], (-2, -1, 1, 2)
+                values_rhs, needed_shifts_rhs = [1/3, 1, 1/3], (-1, 0, 1)
+
+            else:
+                values, needed_shifts = [-17/186, -63/62, 63/62, 17/186], (-1, 0, 1, 2)
+                extrapol_map['symmetric'] = combine_by_direction(REFLECT, SYMMETRIC)
+
+                values_rhs, needed_shifts_rhs = [9/62, 1, 9/62], (-1, 0, 1)
+                extrapol_map_rhs['symmetric'] = combine_by_direction(ANTIREFLECT, ANTISYMMETRIC)
+
+
+    base_widths = (abs(min(needed_shifts)), max(needed_shifts))
+    field.with_extrapolation(map(_ex_map_f(extrapol_map), field.extrapolation))
+
+    if scheme.is_implicit:
+        gradient_extrapolation = map(_ex_map_f(extrapol_map_rhs), gradient_extrapolation)
+
     if type == CenteredGrid:
-        values = math.spatial_gradient(field.values, field.dx.vector.as_channel(name=stack_dim.name), difference='central', padding=field.extrapolation, stack_dim=stack_dim)
-        return CenteredGrid(values, bounds=field.bounds, extrapolation=extrapolation)
-    elif type == StaggeredGrid:
-        assert stack_dim.name == 'vector'
-        return stagger(field, lambda lower, upper: (upper - lower) / field.dx, extrapolation)
-    raise NotImplementedError(f"{type(field)} not supported. Only CenteredGrid and StaggeredGrid allowed.")
+        padded_components = [pad(field, {dim: base_widths}) for dim in field.shape.spatial.names]
+    else:
+        base_widths = (base_widths[0], base_widths[1]-1)
+        padded_components = pad_for_staggered_output(field, gradient_extrapolation,
+                                                     field.shape.spatial.names, base_widths)
+
+    shifted_components = [shift(padded_component, needed_shifts, None, pad=False, dims=dim) for padded_component, dim in zip(padded_components, field.shape.spatial.names)]
+    result_components = [sum([value * shift for value, shift in zip(values, shifted_component)]) / field.dx.vector[dim] for shifted_component, dim in zip(shifted_components, field.shape.spatial.names)]
+
+    if type == CenteredGrid:
+        result = stack(result_components, stack_dim)
+    else:
+        result = StaggeredGrid(math.stack([component.values for component in result_components], channel('vector')),
+                               bounds=field.bounds, extrapolation=gradient_extrapolation)
+
+    result = result.with_extrapolation(gradient_extrapolation)
+
+    if scheme.is_implicit:
+        scheme.solve.x0 = result
+        result = result
+        result = solve_linear(_lhs_for_implicit_scheme, result, solve=scheme.solve,
+                              f_kwargs={"values_rhs": values_rhs, "needed_shifts_rhs": needed_shifts_rhs,
+                                        "stack_dim": stack_dim, "staggered_output": type != CenteredGrid})
+
+    return result.with_bounds(field.bounds)
+
+def _ex_map_f(ext_dict: dict):
+    def f(ext: Extrapolation):
+        return ext_dict[ext.__repr__()] if ext.__repr__() in ext_dict else ext
+    return f
 
 
-def shift(grid: CenteredGrid, offsets: tuple, stack_dim: Shape = channel('shift')):
+@partial(jit_compile_linear, auxiliary_args="values_rhs, needed_shifts_rhs, stack_dim, staggered_output")
+def _lhs_for_implicit_scheme(x, values_rhs, needed_shifts_rhs, stack_dim, staggered_output=False):
+    result = []
+    for dim, component in zip(x.shape.only(math.spatial).names, unstack(x, stack_dim.name)):
+        shifted = shift(component, needed_shifts_rhs, stack_dim=None, dims=dim)
+        result.append(sum([value * shift for value, shift in zip(values_rhs, shifted)]))
+
+    if staggered_output:
+        result = x.with_values(math.stack([component.values for component in result], channel('vector')))
+    else:
+        result = stack(result, stack_dim)
+
+    return result
+
+
+def pad_for_staggered_output(field: CenteredGrid, output_extrapolation: Extrapolation, dims: tuple, base_widths: tuple):
+    padded_components = []
+    for dim in dims:
+        border_valid = output_extrapolation.valid_outer_faces(dim)
+        padding_widths = (border_valid[0] + base_widths[0], border_valid[1] + base_widths[1])
+        padded_components.append(pad(field, {dim: padding_widths}))
+
+    return padded_components
+
+
+def shift(grid: CenteredGrid, offsets: tuple, stack_dim: Shape = channel('shift'), dims=math.spatial,
+          pad: bool = True):
     """
     Wraps :func:`math.shift` for CenteredGrid.
 
@@ -87,8 +231,19 @@ def shift(grid: CenteredGrid, offsets: tuple, stack_dim: Shape = channel('shift'
       offsets: tuple: 
       stack_dim:  (Default value = 'shift')
     """
-    data = math.shift(grid.values, offsets, padding=grid.extrapolation, stack_dim=stack_dim)
-    return [CenteredGrid(data[i], bounds=grid.bounds, extrapolation=grid.extrapolation) for i in range(len(offsets))]
+
+    if pad:
+        padding = grid.extrapolation
+        new_bounds = grid.bounds
+    else:
+        padding = None
+        max_lower_shift = min(offsets) if min(offsets) < 0 else 0
+        max_upper_shift = max(offsets) if max(offsets) > 0 else 0
+        w_lower = math.wrap([max_lower_shift if dim in dims else 0 for dim in grid.shape.spatial.names])
+        w_upper = math.wrap([max_upper_shift if dim in dims else 0 for dim in grid.shape.spatial.names])
+        new_bounds = Box(grid.box.lower - w_lower * grid.dx, grid.box.upper - w_upper * grid.dx)
+    data = math.shift(grid.values, offsets, dims=dims, padding=padding, stack_dim=stack_dim)
+    return [type(grid)(data[i], bounds=new_bounds, extrapolation=grid.extrapolation) for i in range(len(offsets))]
 
 
 def stagger(field: CenteredGrid,
@@ -141,7 +296,7 @@ def stagger(field: CenteredGrid,
         raise ValueError(type)
 
 
-def divergence(field: Grid) -> CenteredGrid:
+def divergence(field: Grid, scheme: Scheme = Scheme(2)) -> CenteredGrid:
     """
     Computes the divergence of a grid using finite differences.
 
@@ -152,26 +307,69 @@ def divergence(field: Grid) -> CenteredGrid:
 
     Args:
         field: vector field as `CenteredGrid` or `StaggeredGrid`
+        scheme: finite difference `Scheme` used for differentiation
 
     Returns:
         Divergence field as `CenteredGrid`
     """
-    if isinstance(field, StaggeredGrid):
-        field = bake_extrapolation(field)
-        components = []
-        for dim in field.shape.spatial.names:
-            div_dim = math.spatial_gradient(field.values.vector[dim], field.dx, 'forward', None, dims=dim, stack_dim=None)
-            components.append(div_dim)
-        data = math.sum(components, dim='0')
-        return CenteredGrid(data, bounds=field.bounds, extrapolation=field.extrapolation.spatial_gradient())
-    elif isinstance(field, CenteredGrid):
-        left, right = shift(field, (-1, 1), stack_dim=batch('div_'))
-        grad = (right - left) / (field.dx * 2)
-        components = [grad.vector[i].div_[i] for i in range(grad.div_.size)]
-        result = sum(components)
-        return result
+
+    extrapol_map = {}
+    if not scheme.is_implicit:
+        if scheme.order == 2:
+            if isinstance(field, CenteredGrid):
+                values, needed_shifts = [-1 / 2, 1 / 2], (-1, 1)
+            else:
+                values, needed_shifts = [-1, 1], (0, 1)
+
+        elif scheme.order == 4:
+            if isinstance(field, CenteredGrid):
+                values, needed_shifts = [1 / 12, -2 / 3, 2 / 3, -1 / 12], (-2, -1, 1, 2)
+            else:
+                values, needed_shifts = [1 / 24, -27 / 24, 27 / 24, -1 / 24], (-1, 0, 1, 2)
     else:
-        raise NotImplementedError(f"{type(field)} not supported. Only StaggeredGrid allowed.")
+        extrapol_map_rhs = {}
+        if scheme.order == 6:
+            extrapol_map['symmetric'] = combine_by_direction(REFLECT, SYMMETRIC)
+            extrapol_map_rhs['symmetric'] = combine_by_direction(ANTIREFLECT, ANTISYMMETRIC)
+
+            if isinstance(field, CenteredGrid):
+                values, needed_shifts = [-1 / 36, -14 / 18, 14 / 18, 1 / 36], (-2, -1, 1, 2)
+                values_rhs, needed_shifts_rhs = [1 / 3, 1, 1 / 3], (-1, 0, 1)
+
+            else:
+                values, needed_shifts = [-17 / 186, -63 / 62, 63 / 62, 17 / 186], (-1, 0, 1, 2)
+                values_rhs, needed_shifts_rhs = [9 / 62, 1, 9 / 62], (-1, 0, 1)
+
+
+    base_widths = (abs(min(needed_shifts)), max(needed_shifts))
+    field.with_extrapolation(map(_ex_map_f(extrapol_map), field.extrapolation))
+
+
+    if isinstance(field, StaggeredGrid):
+        base_widths = (base_widths[0]+1, base_widths[1])
+        padded_components = []
+        for dim, component in zip(field.shape.spatial.names, unstack(field, 'vector')):
+            border_valid = field.extrapolation.valid_outer_faces(dim)
+            padding_widths = (base_widths[0] - border_valid[0], base_widths[1] - border_valid[1])
+            padded_components.append(pad(component, {dim: padding_widths}))
+    elif isinstance(field, CenteredGrid):
+        padded_components = [pad(component, {dim: base_widths}) for dim, component in zip(field.shape.spatial.names, unstack(field, 'vector'))]
+
+    shifted_components = [shift(padded_component, needed_shifts, None, pad=False, dims=dim) for padded_component, dim in zip(padded_components, field.shape.spatial.names)]
+    result_components = [sum([value * shift for value, shift in zip(values, shifted_component)]) / field.dx.vector[dim] for shifted_component, dim in zip(shifted_components, field.shape.spatial.names)]
+
+    if scheme.is_implicit:
+        result_components = stack(result_components, channel('vector'))
+        result_components.with_values(result_components.values._cache())
+        scheme.solve.x0 = field
+        result_components = solve_linear(_lhs_for_implicit_scheme, result_components, solve=scheme.solve,
+                                         f_kwargs={"values_rhs": values_rhs, "needed_shifts_rhs": needed_shifts_rhs,
+                                        "stack_dim": channel('vector')})
+        result_components = unstack(result_components, 'vector')
+
+    result_components = [component.with_bounds(field.bounds) for component in result_components]
+    result = sum(result_components)
+    return result
 
 
 def curl(field: Grid, type: type = CenteredGrid):
@@ -307,7 +505,7 @@ def pad(grid: GridType, widths: int or tuple or list or dict) -> GridType:
         widths = {axis: (width if isinstance(width, (tuple, list)) else (width, width)) for axis, width in zip(grid.shape.spatial.names, widths)}
     else:
         assert isinstance(widths, dict)
-    widths_list = [widths[axis] for axis in grid.shape.spatial.names]
+    widths_list = [widths[axis] if axis in widths.keys() else (0, 0) for axis in grid.shape.spatial.names]
     if isinstance(grid, Grid):
         data = math.pad(grid.values, widths, grid.extrapolation, bounds=grid.bounds)
         w_lower = math.wrap([w[0] for w in widths_list])

--- a/phi/math/__init__.py
+++ b/phi/math/__init__.py
@@ -60,7 +60,7 @@ from ._nd import (
     spatial_gradient, laplace,
     fourier_laplace, fourier_poisson, abs_square,
     downsample2x, upsample2x, sample_subgrid,
-    masked_fill, finite_fill,
+    masked_fill, finite_fill
 )
 from ._functional import (
     LinearFunction, jit_compile_linear, jit_compile,

--- a/phi/math/_nd.py
+++ b/phi/math/_nd.py
@@ -1,10 +1,12 @@
-from typing import Tuple, Optional
+from functools import partial
+from typing import Tuple, Optional, List
 
 import numpy as np
 
 from . import _ops as math
 from . import extrapolation as extrapolation
 from ._magic_ops import stack, rename_dims, concat, variable_values
+from ._functional import solve_linear, jit_compile_linear
 from ._shape import Shape, channel, batch, spatial, DimFilter, parse_dim_order
 from ._tensors import Tensor, wrap
 from .magic import PhiTreeNode
@@ -646,6 +648,54 @@ def sample_subgrid(grid: Tensor, start: Tensor, size: Shape) -> Tensor:
             lower, upper = shift(grid, (0, 1), [dim], padding=None, stack_dim=None)
             grid = upper * upper_weight[i] + lower * lower_weight[i]
     return grid
+
+
+def _dyadic_interpolate(grid: Tensor, interpolation_dirs: List, padding: Extrapolation, scheme):
+    """
+    Samples a sub-grid from `grid` with an offset of half a grid cell in directions defined by `interpolation_dirs`.
+
+    Args:
+        grid: `Tensor` to be resampled.
+        interpolation_dirs: List which defines for every spatial dimension of `grid` if interpolation should be performed,
+            in positive direction `1` / negative direction `-1` / no interpolation`0`
+            len(interpolation_dirs) == len(grid.shape.spatial.names) is assumed
+            Example: With `grid.shape.spatial.names=['x', 'y']` and `interpolation_dirs: [1, -1]`
+                     grid will be interpolated half a grid cell in positive x direction and half a grid cell in negative y direction
+        padding: Extrapolation used for the needed out of Domain values
+        scheme: finite difference `Scheme` used for interpolation
+
+    Returns:
+      Sub-grid as `Tensor`
+    """
+    if scheme.is_implicit:
+        if scheme.order == 6:
+            values, needed_shifts = [1 / 20, 3 / 4, 3 / 4, 1 / 20], (-1, 0, 1, 2)
+            values_rhs, needed_shifts_rhs = [3 / 10, 1, 3 / 10], (-1, 0, 1)
+        else:
+            return NotImplemented
+    else:
+        return NotImplemented
+
+    result = grid
+    for dim, dir in zip(grid.shape.spatial.names, interpolation_dirs):
+        if dir == 0: continue
+        is_neg_dir = dir == -1
+        current_widths = [abs(min(needed_shifts)) + is_neg_dir, max(needed_shifts) - is_neg_dir]
+        padded = math.pad(result, {dim: tuple(current_widths)}, padding)
+        shifted = shift(padded, needed_shifts, [dim], padding=None, stack_dim=None)
+        result = sum([value * shift for value, shift in zip(values, shifted)])
+
+        if scheme.is_implicit:
+            scheme.solve.x0 = result
+            result = solve_linear(dyadic_interpolate_lhs, result, solve=scheme.solve,
+                                  f_kwargs={"values_rhs": values_rhs, "needed_shifts_rhs": needed_shifts_rhs,
+                                            "dim": dim, "padding": padding})
+    return result
+
+@partial(jit_compile_linear, auxiliary_args="values_rhs, needed_shifts_rhs")
+def dyadic_interpolate_lhs(x, values_rhs, needed_shifts_rhs, dim, padding):
+    shifted = shift(x, needed_shifts_rhs, stack_dim=None, dims=[dim], padding=padding)
+    return sum([value * shift for value, shift in zip(values_rhs, shifted)])
 
 
 # Poisson Brackets

--- a/phi/math/extrapolation.py
+++ b/phi/math/extrapolation.py
@@ -607,6 +607,63 @@ class _SymmetricExtrapolation(_CopyExtrapolation):
         else:
             return value[{dim: slice(0, width)}].flip(dim)
 
+    def _pad_linear_tracer(self, value: 'ShiftLinTracer', widths: dict) -> 'ShiftLinTracer':
+        """
+        *Warning*:
+        This implementation discards corners, i.e. values that lie outside the original tensor in more than one dimension.
+        These are typically sliced off in differential operators. Corners are instead assigned the value 0.
+        To take corners into account, call pad() for each axis individually. This is inefficient with ShiftLinTracer.
+
+        Args:
+          value: ShiftLinTracer:
+          widths: dict:
+
+        Returns:
+
+        """
+        lower = {dim: -lo for dim, (lo, _) in widths.items()}
+        result = value.shift(lower, new_shape=value.shape.after_pad(widths), val_fun=lambda v: ZERO.pad(v, widths), bias_fun=lambda b: ZERO.pad(b, widths))  # inner values  ~half the computation time
+        for bound_dim, (bound_lo, bound_hi) in widths.items():
+            for i in range(bound_lo):  # i=0 means outer
+                # this sets corners to 0
+                lower = {dim: bound_lo-1-2*i if dim == bound_dim else -lo for dim, (lo, _) in widths.items()}
+                mask = self._lower_mask(value.shape.only(result.dependent_dims), widths, bound_dim, bound_lo, bound_hi, i)
+                boundary = value.shift(lower, new_shape=result.shape, val_fun=lambda v: self.pad(v, widths) * mask, bias_fun=lambda b: ZERO.pad(b, widths))
+                result += boundary
+            for i in range(bound_hi):
+                lower = {dim: -(bound_hi-1-2*i) - bound_lo - bound_hi if dim == bound_dim else -lo for dim, (lo, hi) in widths.items()}
+                mask = self._upper_mask(value.shape.only(result.dependent_dims), widths, bound_dim, bound_lo, bound_hi, i)
+                boundary = value.shift(lower, new_shape=result.shape, val_fun=lambda v: self.pad(v, widths) * mask, bias_fun=lambda b: ZERO.pad(b, widths))  # ~ half the computation time
+                result += boundary  # this does basically nothing if value is the identity
+        return result
+
+    def _lower_mask(self, shape, widths, bound_dim, bound_lo, bound_hi, i):
+        # key = (shape, tuple(widths.keys()), tuple(widths.values()), bound_dim, bound_lo, bound_hi, i)
+        # if key in _BoundaryExtrapolation._CACHED_LOWER_MASKS:
+        #     result = math.tensor(_BoundaryExtrapolation._CACHED_LOWER_MASKS[key])
+        #     _BoundaryExtrapolation._CACHED_LOWER_MASKS[key] = result
+        #     return result
+        # else:
+            mask = ZERO.pad(math.zeros(shape), {bound_dim: (bound_lo - i - 1, 0)})
+            mask = ONE.pad(mask, {bound_dim: (1, 0)})
+            mask = ZERO.pad(mask, {dim: (i, bound_hi) if dim == bound_dim else (lo, hi) for dim, (lo, hi) in widths.items()})
+            # _BoundaryExtrapolation._CACHED_LOWER_MASKS[key] = mask
+            return mask
+
+    def _upper_mask(self, shape, widths, bound_dim, bound_lo, bound_hi, i):
+        # key = (shape, tuple(widths.keys()), tuple(widths.values()), bound_dim, bound_lo, bound_hi, i)
+        # if key in _BoundaryExtrapolation._CACHED_UPPER_MASKS:
+        #     result = math.tensor(_BoundaryExtrapolation._CACHED_UPPER_MASKS[key])
+        #     _BoundaryExtrapolation._CACHED_UPPER_MASKS[key] = result
+        #     return result
+        # else:
+            mask = ZERO.pad(math.zeros(shape), {bound_dim: (0, bound_hi - i - 1)})
+            mask = ONE.pad(mask, {bound_dim: (0, 1)})
+            mask = ZERO.pad(mask, {dim: (bound_lo, i) if dim == bound_dim else (lo, hi) for dim, (lo, hi) in widths.items()})
+            # _BoundaryExtrapolation._CACHED_UPPER_MASKS[key] = mask
+            return mask
+
+
 class _AntiSymmetricExtrapolation(_SymmetricExtrapolation):
     """Like _SymmetricExtrapolation but symmetric counterparts are negated for padding"""
 
@@ -615,6 +672,36 @@ class _AntiSymmetricExtrapolation(_SymmetricExtrapolation):
 
     def pad_values(self, *args, **kwargs) -> Tensor:
         return -super().pad_values(*args, **kwargs)
+
+    def _pad_linear_tracer(self, value: 'ShiftLinTracer', widths: dict) -> 'ShiftLinTracer':
+        """
+        *Warning*:
+        This implementation discards corners, i.e. values that lie outside the original tensor in more than one dimension.
+        These are typically sliced off in differential operators. Corners are instead assigned the value 0.
+        To take corners into account, call pad() for each axis individually. This is inefficient with ShiftLinTracer.
+
+        Args:
+          value: ShiftLinTracer:
+          widths: dict:
+
+        Returns:
+
+        """
+        lower = {dim: -lo for dim, (lo, _) in widths.items()}
+        result = value.shift(lower, new_shape=value.shape.after_pad(widths), val_fun=lambda v: ZERO.pad(v, widths), bias_fun=lambda b: ZERO.pad(b, widths))  # inner values  ~half the computation time
+        for bound_dim, (bound_lo, bound_hi) in widths.items():
+            for i in range(bound_lo):  # i=0 means outer
+                # this sets corners to 0
+                lower = {dim: bound_lo-1-2*i if dim == bound_dim else -lo for dim, (lo, _) in widths.items()}
+                mask = self._lower_mask(value.shape.only(result.dependent_dims), widths, bound_dim, bound_lo, bound_hi, i)
+                boundary = value.shift(lower, new_shape=result.shape, val_fun=lambda v: self.pad(v, widths) * mask, bias_fun=lambda b: ZERO.pad(b, widths))
+                result -= boundary
+            for i in range(bound_hi):
+                lower = {dim: -(bound_hi-1-2*i) - bound_lo - bound_hi if dim == bound_dim else -lo for dim, (lo, hi) in widths.items()}
+                mask = self._upper_mask(value.shape.only(result.dependent_dims), widths, bound_dim, bound_lo, bound_hi, i)
+                boundary = value.shift(lower, new_shape=result.shape, val_fun=lambda v: self.pad(v, widths) * mask, bias_fun=lambda b: ZERO.pad(b, widths))  # ~ half the computation time
+                result -= boundary  # this does basically nothing if value is the identity
+        return result
 
 
 class _ReflectExtrapolation(_CopyExtrapolation):
@@ -640,6 +727,62 @@ class _ReflectExtrapolation(_CopyExtrapolation):
         coordinates = coordinates % (2 * shape - 2)
         return (shape - 1) - math.abs_((shape - 1) - coordinates)
 
+    def _pad_linear_tracer(self, value: 'ShiftLinTracer', widths: dict) -> 'ShiftLinTracer':
+        """
+        *Warning*:
+        This implementation discards corners, i.e. values that lie outside the original tensor in more than one dimension.
+        These are typically sliced off in differential operators. Corners are instead assigned the value 0.
+        To take corners into account, call pad() for each axis individually. This is inefficient with ShiftLinTracer.
+
+        Args:
+          value: ShiftLinTracer:
+          widths: dict:
+
+        Returns:
+
+        """
+        lower = {dim: -lo for dim, (lo, _) in widths.items()}
+        result = value.shift(lower, new_shape=value.shape.after_pad(widths), val_fun=lambda v: ZERO.pad(v, widths), bias_fun=lambda b: ZERO.pad(b, widths))  # inner values  ~half the computation time
+        for bound_dim, (bound_lo, bound_hi) in widths.items():
+            for i in range(bound_lo):  # i=0 means outer
+                # this sets corners to 0
+                lower = {dim: bound_lo-2*i if dim == bound_dim else -lo for dim, (lo, _) in widths.items()}
+                mask = self._lower_mask(value.shape.only(result.dependent_dims), widths, bound_dim, bound_lo, bound_hi, i)
+                boundary = value.shift(lower, new_shape=result.shape, val_fun=lambda v: self.pad(v, widths) * mask, bias_fun=lambda b: ZERO.pad(b, widths))
+                result += boundary
+            for i in range(bound_hi):
+                lower = {dim: -(bound_hi-2*i) - bound_lo - bound_hi if dim == bound_dim else -lo for dim, (lo, hi) in widths.items()}
+                mask = self._upper_mask(value.shape.only(result.dependent_dims), widths, bound_dim, bound_lo, bound_hi, i)
+                boundary = value.shift(lower, new_shape=result.shape, val_fun=lambda v: self.pad(v, widths) * mask, bias_fun=lambda b: ZERO.pad(b, widths))  # ~ half the computation time
+                result += boundary  # this does basically nothing if value is the identity
+        return result
+
+    def _lower_mask(self, shape, widths, bound_dim, bound_lo, bound_hi, i):
+        # key = (shape, tuple(widths.keys()), tuple(widths.values()), bound_dim, bound_lo, bound_hi, i)
+        # if key in _BoundaryExtrapolation._CACHED_LOWER_MASKS:
+        #     result = math.tensor(_BoundaryExtrapolation._CACHED_LOWER_MASKS[key])
+        #     _BoundaryExtrapolation._CACHED_LOWER_MASKS[key] = result
+        #     return result
+        # else:
+            mask = ZERO.pad(math.zeros(shape), {bound_dim: (bound_lo - i - 1, 0)})
+            mask = ONE.pad(mask, {bound_dim: (1, 0)})
+            mask = ZERO.pad(mask, {dim: (i, bound_hi) if dim == bound_dim else (lo, hi) for dim, (lo, hi) in widths.items()})
+            # _BoundaryExtrapolation._CACHED_LOWER_MASKS[key] = mask
+            return mask
+
+    def _upper_mask(self, shape, widths, bound_dim, bound_lo, bound_hi, i):
+        # key = (shape, tuple(widths.keys()), tuple(widths.values()), bound_dim, bound_lo, bound_hi, i)
+        # if key in _BoundaryExtrapolation._CACHED_UPPER_MASKS:
+        #     result = math.tensor(_BoundaryExtrapolation._CACHED_UPPER_MASKS[key])
+        #     _BoundaryExtrapolation._CACHED_UPPER_MASKS[key] = result
+        #     return result
+        # else:
+            mask = ZERO.pad(math.zeros(shape), {bound_dim: (0, bound_hi - i - 1)})
+            mask = ONE.pad(mask, {bound_dim: (0, 1)})
+            mask = ZERO.pad(mask, {dim: (bound_lo, i) if dim == bound_dim else (lo, hi) for dim, (lo, hi) in widths.items()})
+            # _BoundaryExtrapolation._CACHED_UPPER_MASKS[key] = mask
+            return mask
+
 
 class _AntiReflectExtrapolation(_ReflectExtrapolation):
     """Like _ReflectExtrapolation but symmetric counterparts are negated for padding"""
@@ -649,6 +792,36 @@ class _AntiReflectExtrapolation(_ReflectExtrapolation):
 
     def pad_values(self, *args, **kwargs) -> Tensor:
         return -super().pad_values(*args, **kwargs)
+
+    def _pad_linear_tracer(self, value: 'ShiftLinTracer', widths: dict) -> 'ShiftLinTracer':
+        """
+        *Warning*:
+        This implementation discards corners, i.e. values that lie outside the original tensor in more than one dimension.
+        These are typically sliced off in differential operators. Corners are instead assigned the value 0.
+        To take corners into account, call pad() for each axis individually. This is inefficient with ShiftLinTracer.
+
+        Args:
+          value: ShiftLinTracer:
+          widths: dict:
+
+        Returns:
+
+        """
+        lower = {dim: -lo for dim, (lo, _) in widths.items()}
+        result = value.shift(lower, new_shape=value.shape.after_pad(widths), val_fun=lambda v: ZERO.pad(v, widths), bias_fun=lambda b: ZERO.pad(b, widths))  # inner values  ~half the computation time
+        for bound_dim, (bound_lo, bound_hi) in widths.items():
+            for i in range(bound_lo):  # i=0 means outer
+                # this sets corners to 0
+                lower = {dim: bound_lo-2*i if dim == bound_dim else -lo for dim, (lo, _) in widths.items()}
+                mask = self._lower_mask(value.shape.only(result.dependent_dims), widths, bound_dim, bound_lo, bound_hi, i)
+                boundary = value.shift(lower, new_shape=result.shape, val_fun=lambda v: self.pad(v, widths) * mask, bias_fun=lambda b: ZERO.pad(b, widths))
+                result -= boundary
+            for i in range(bound_hi):
+                lower = {dim: -(bound_hi-2*i) - bound_lo - bound_hi if dim == bound_dim else -lo for dim, (lo, hi) in widths.items()}
+                mask = self._upper_mask(value.shape.only(result.dependent_dims), widths, bound_dim, bound_lo, bound_hi, i)
+                boundary = value.shift(lower, new_shape=result.shape, val_fun=lambda v: self.pad(v, widths) * mask, bias_fun=lambda b: ZERO.pad(b, widths))  # ~ half the computation time
+                result -= boundary  # this does basically nothing if value is the identity
+        return result
 
 
 class _NoExtrapolation(Extrapolation):  # singleton

--- a/phi/math/extrapolation.py
+++ b/phi/math/extrapolation.py
@@ -644,6 +644,9 @@ class _ReflectExtrapolation(_CopyExtrapolation):
 class _AntiReflectExtrapolation(_ReflectExtrapolation):
     """Like _ReflectExtrapolation but symmetric counterparts are negated for padding"""
 
+    def __repr__(self):
+        return 'antireflect'
+
     def pad_values(self, *args, **kwargs) -> Tensor:
         return -super().pad_values(*args, **kwargs)
 
@@ -780,9 +783,11 @@ BOUNDARY = _BoundaryExtrapolation(2)
 SYMMETRIC = _SymmetricExtrapolation(3)
 """ Extends a grid by tiling it. Every other copy of the grid is flipped. Edge values occur twice per seam. """
 ANTISYMMETRIC = _AntiSymmetricExtrapolation(3)
+""" Like REFLECT but extends a grid with the negative value of the corresponding counterpart instead. """
 REFLECT = _ReflectExtrapolation(4)
 """ Like SYMMETRIC but the edge values are not copied and only occur once per seam. """
 ANTIREFLECT = _AntiReflectExtrapolation(4)
+""" Like REFLECT but extends a grid with the negative value of the corresponding counterpart instead. """
 
 NONE = _NoExtrapolation(-1)
 """ Raises AssertionError when used to determine outside values. Padding operations will have no effect with this extrapolation. """

--- a/phi/physics/advect.py
+++ b/phi/physics/advect.py
@@ -8,8 +8,7 @@ Examples:
 * runge_kutta_4 (particle)
 """
 from phi import math
-from phi.field import SampledField, Field, PointCloud, Grid, sample, reduce_sample, \
-    spatial_gradient, unstack, stack, CenteredGrid, StaggeredGrid
+from phi.field import SampledField, Field, PointCloud, Grid, sample, reduce_sample, spatial_gradient, unstack, stack, CenteredGrid, StaggeredGrid
 from phi.field._field import FieldType
 from phi.field._field_math import GridType
 from phi.field.numerical import Scheme
@@ -50,8 +49,7 @@ def advect(field: SampledField,
            velocity: Field,
            dt: float or math.Tensor,
            integrator=euler,
-           scheme: Scheme = None
-           ) -> FieldType:
+           scheme: Scheme = None) -> FieldType:
     """
     Advect `field` along the `velocity` vectors using the specified integrator.
 
@@ -65,6 +63,8 @@ def advect(field: SampledField,
         velocity: Any `phi.field.Field` that can be sampled in the elements of `field`.
         dt: Time increment
         integrator: ODE integrator for solving the movement.
+        scheme: differentiation 'Scheme' if provided 'finite_difference' is used
+            if 'None' is given other functions are used which is the case by default
 
     Returns:
         Advected field of same type as `field`
@@ -92,17 +92,16 @@ def finite_difference(grid: Grid,
         velocity: `Grid` that can be sampled in the elements of `grid`.
         dt: Time increment
         scheme: finite difference `Scheme` used for differentiation
+            supported: explicit 2/4th order - implicit 6th order
 
     Returns:
         Advected grid of same type as `grid`
     """
 
-
     if isinstance(grid, StaggeredGrid):
         field_components = unstack(grid, 'vector')
         grad_list = [spatial_gradient(field_component, stack_dim=math.channel('gradient'), scheme=scheme) for
-                     field_component in
-                     field_components]
+                     field_component in field_components]
         grad_grid = grid.with_values(math.stack([component.values for component in grad_list], math.channel('vector')))
         velocity._scheme = True
         ammounts = [grad * vel.at(grad, scheme=scheme) for grad, vel in

--- a/phi/physics/advect.py
+++ b/phi/physics/advect.py
@@ -8,9 +8,11 @@ Examples:
 * runge_kutta_4 (particle)
 """
 from phi import math
-from phi.field import SampledField, Field, PointCloud, Grid, sample, reduce_sample
+from phi.field import SampledField, Field, PointCloud, Grid, sample, reduce_sample, \
+    spatial_gradient, unstack, stack, CenteredGrid, StaggeredGrid
 from phi.field._field import FieldType
 from phi.field._field_math import GridType
+from phi.field.numerical import Scheme
 from phi.geom import Geometry
 
 
@@ -47,7 +49,9 @@ def finite_rk4(elements: Geometry, velocity: Grid, dt: float, v0: math.Tensor = 
 def advect(field: SampledField,
            velocity: Field,
            dt: float or math.Tensor,
-           integrator=euler) -> FieldType:
+           integrator=euler,
+           scheme: Scheme = None
+           ) -> FieldType:
     """
     Advect `field` along the `velocity` vectors using the specified integrator.
 
@@ -65,11 +69,52 @@ def advect(field: SampledField,
     Returns:
         Advected field of same type as `field`
     """
+
+    if scheme is not None and isinstance(field, Grid):
+        return finite_difference(field, velocity, dt=dt, scheme=scheme)
     if isinstance(field, PointCloud):
         return points(field, velocity, dt=dt, integrator=integrator)
     elif isinstance(field, Grid):
         return semi_lagrangian(field, velocity, dt=dt, integrator=integrator)
     raise NotImplementedError(field)
+
+
+def finite_difference(grid: Grid,
+                      velocity: Field,
+                      dt: float or math.Tensor,
+                      scheme: Scheme = Scheme(2)) -> Field:
+
+    """
+    Finite difference advection using the differentiation Scheme indicated by `scheme` and a simple Euler step
+
+    Args:
+        grid: Grid to be advected
+        velocity: `Grid` that can be sampled in the elements of `grid`.
+        dt: Time increment
+        scheme: finite difference `Scheme` used for differentiation
+
+    Returns:
+        Advected grid of same type as `grid`
+    """
+
+
+    if isinstance(grid, StaggeredGrid):
+        field_components = unstack(grid, 'vector')
+        grad_list = [spatial_gradient(field_component, stack_dim=math.channel('gradient'), scheme=scheme) for
+                     field_component in
+                     field_components]
+        grad_grid = grid.with_values(math.stack([component.values for component in grad_list], math.channel('vector')))
+        velocity._scheme = True
+        ammounts = [grad * vel.at(grad, scheme=scheme) for grad, vel in
+                    zip(unstack(grad_grid, dim='gradient'), unstack(velocity, dim='vector'))]
+        ammount = sum(ammounts)
+    else:
+        grad = spatial_gradient(grid, stack_dim=math.channel('gradient'), scheme=scheme)
+        velocity = stack(unstack(velocity, dim='vector'), dim=math.channel('gradient'))
+        ammounts = velocity * grad
+        ammount = sum(unstack(ammounts, dim='gradient'))
+
+    return grid - dt * ammount
 
 
 def points(field: PointCloud, velocity: Field, dt: float, integrator=euler):

--- a/phi/physics/diffuse.py
+++ b/phi/physics/diffuse.py
@@ -5,6 +5,7 @@ from phi import math
 from phi.field import Grid, Field, laplace, solve_linear, jit_compile_linear
 from phi.field._field import FieldType
 from phi.field._grid import GridType
+from phi.field.numerical import Scheme
 from phi.math import copy_with
 
 
@@ -61,6 +62,33 @@ def implicit(field: FieldType,
     if not solve.x0:
         solve = copy_with(solve, x0=field)
     return solve_linear(sharpen, y=field, solve=solve)
+
+
+def finite_difference(grid: Grid,
+                      diffusivity: float or math.Tensor or Field,
+                      dt: float or math.Tensor,
+                      scheme: Scheme = Scheme(2)) -> FieldType:
+
+    """
+    Diffusion by using a finite difference scheme.
+
+
+    Args:
+        grid: CenteredGrid or StaggeredGrid
+        diffusivity: Diffusion per time. `diffusion_amount = diffusivity * dt`
+        dt: Time interval. `diffusion_amount = diffusivity * dt`
+        scheme: finite difference `Scheme` used for differentiation
+
+    Returns:
+        Diffused grid of same type as `grid`.
+    """
+
+    amount = diffusivity * dt
+    if isinstance(amount, Field):
+        amount = amount.at(grid)
+
+    grid += amount * laplace(grid, scheme=scheme).with_extrapolation(grid.extrapolation)
+    return grid
 
 
 def fourier(field: GridType,

--- a/phi/physics/diffuse.py
+++ b/phi/physics/diffuse.py
@@ -71,13 +71,15 @@ def finite_difference(grid: Grid,
 
     """
     Diffusion by using a finite difference scheme.
-
+    In contrast to `explicit` and `implicit` accuracy can be increased by using stencils of higher-order rather than calculating substeps.
+    This is controlled by the `scheme` passed.
 
     Args:
         grid: CenteredGrid or StaggeredGrid
         diffusivity: Diffusion per time. `diffusion_amount = diffusivity * dt`
         dt: Time interval. `diffusion_amount = diffusivity * dt`
         scheme: finite difference `Scheme` used for differentiation
+            supported: explicit 2/4th order - implicit 6th order
 
     Returns:
         Diffused grid of same type as `grid`.

--- a/phi/physics/fluid.py
+++ b/phi/physics/fluid.py
@@ -69,7 +69,9 @@ def make_incompressible(velocity: GridType,
             If given, the velocity may take `NaN` values where it does not contribute to the pressure.
             Also, the total divergence will never be subtracted if active is given, even if all values are 1.
         scheme: finite difference `Scheme` used for differentiation
-
+            For Higher-order schemes the laplace operation is not conducted with a stencil exactly corresponding to the one used in divergence calculations but a smaller one instead,
+            while this disrupts the formal correctness of the method it only induces insignificant errors and yields considerable performance gains
+            supported: explicit 2/4th order - implicit 6th order (obstacles are only supported with explicit 2nd order)
 
     Returns:
         velocity: divergence-free velocity of type `type(velocity)`
@@ -124,6 +126,7 @@ def masked_laplace(pressure: CenteredGrid, hard_bcs: Grid, active: CenteredGrid,
         active: Mask indicating for which cells the pressure value is valid.
             Linear solves will only determine the pressure for these cells.
             This is generally zero inside obstacles and in non-simulated regions.
+        scheme: finite difference `Scheme` used for laplace calculation
 
     Returns:
         `CenteredGrid`


### PR DESCRIPTION
[field] extend spatial_gradient, laplace, divergence in _field_math to arbitrary finite difference schemes by adding the Scheme argument
[field] introduce dyadic interpolation for resampling grids with an offset of exactly half a cell 
[math] add tensor implementation for dyadic interpolation in _nd 
[math] add ANTISYMMETRIC and ANTIREFLECT extrapolations for later use in higher order boundaries 
[physics] extend advect, diffuse by universal finite_difference implementations [physics] Add Scheme to make_incompressible()