### PR TITLE
Refactor to fix type unions

### DIFF
--- a/phi/field/_angular_velocity.py
+++ b/phi/field/_angular_velocity.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from typing import Callable, Union
 from numbers import Number
 
 from phi import math
@@ -18,8 +18,8 @@ class AngularVelocity(Field):
     """
 
     def __init__(self,
-                 location: Tensor or tuple or list or Number,
-                 strength: Tensor or Number = 1.0,
+                 location: Union[Tensor, tuple, list, Number],
+                 strength: Union[Tensor, Number] = 1.0,
                  falloff: Callable = None,
                  component: str = None):
         location = wrap(location)

--- a/phi/field/_field.py
+++ b/phi/field/_field.py
@@ -143,8 +143,8 @@ class SampledField(Field):
     def __init__(self,
                  elements: Union[Geometry, Tensor],
                  values: Tensor,
-                 extrapolation: float or Extrapolation or Field or None,
-                 bounds: Box or None):
+                 extrapolation: Union[float, Extrapolation, Field, None],
+                 bounds: Union[Box, None]):
         """
         Args:
           elements: Geometry object specifying the sample points and sizes
@@ -297,8 +297,8 @@ class SampledField(Field):
             return self.with_values(values)
 
 
-def sample(field: Field or Geometry,
-           geometry: Geometry or SampledField or Tensor,
+def sample(field: Union[Field, Geometry],
+           geometry: Union[Geometry, SampledField, Tensor],
            **kwargs) -> math.Tensor:
     """
     Computes the field value inside the volume of the (batched) `geometry`.
@@ -339,8 +339,8 @@ def sample(field: Field or Geometry,
         return field._sample(geometry, **kwargs)
 
 
-def reduce_sample(field: Field or Geometry,
-                  geometry: Geometry or SampledField or Tensor,
+def reduce_sample(field: Union[Field, Geometry],
+                  geometry: Union[Geometry, SampledField, Tensor],
                   dim=channel('vector'),
                   **kwargs) -> math.Tensor:
     """
@@ -444,7 +444,7 @@ FieldType = TypeVar('FieldType', bound=Field)
 SampledFieldType = TypeVar('SampledFieldType', bound=SampledField)
 
 
-def as_extrapolation(obj: Extrapolation or float or Field or None) -> Extrapolation:
+def as_extrapolation(obj: Union[Extrapolation, float, Field, None]) -> Extrapolation:
     """
     Returns an `Extrapolation` representing `obj`.
 

--- a/phi/field/_field_io.py
+++ b/phi/field/_field_io.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 import numpy as np
 
 from phi import geom
@@ -7,7 +9,7 @@ from ._field_math import stack
 from ..math import extrapolation, wrap, tensor, Shape, channel, Tensor, spatial
 
 
-def write(field: SampledField, file: str or Tensor):
+def write(field: SampledField, file: Union[str, Tensor]):
     """
     Writes a field to disc using a NumPy file format.
     Depending on `file`, the data may be split up into multiple files.
@@ -64,7 +66,7 @@ def write_single_field(field: SampledField, file: str):
         raise NotImplementedError(f"{type(field)} not implemented. Only Grid allowed.")
 
 
-def read(file: str or Tensor, convert_to_backend=True) -> SampledField:
+def read(file: Union[str, Tensor], convert_to_backend=True) -> SampledField:
     """
     Loads a previously saved `SampledField` from disc.
 

--- a/phi/field/_field_math.py
+++ b/phi/field/_field_math.py
@@ -1,6 +1,6 @@
 import warnings
 from numbers import Number
-from typing import Callable, List, Tuple, Optional
+from typing import Callable, List, Tuple, Optional, Union
 
 from phi import geom
 from phi import math
@@ -42,7 +42,7 @@ def laplace(field: GridType,
             axes=spatial,
             order=2,
             implicit: math.Solve = None,
-            weights: Tensor or Field = None) -> GridType:
+            weights: Union[Tensor, Field] = None) -> GridType:
     """
     Spatial Laplace operator for scalar grid.
     If a vector grid is passed, it is assumed to be centered and the laplace is computed component-wise.
@@ -256,7 +256,7 @@ def shift(grid: CenteredGrid, offsets: tuple, stack_dim: Optional[Shape] = chann
 
 def stagger(field: CenteredGrid,
             face_function: Callable,
-            extrapolation: float or math.extrapolation.Extrapolation,
+            extrapolation: Union[float, math.extrapolation.Extrapolation],
             type: type = StaggeredGrid):
     """
     Creates a new grid by evaluating `face_function` given two neighbouring cells.
@@ -432,7 +432,7 @@ def fourier_poisson(grid: GridType, times=1) -> GridType:
     return type(grid)(values=values, bounds=grid.bounds, extrapolation=grid.extrapolation)
 
 
-def native_call(f, *inputs, channels_last=None, channel_dim='vector', extrapolation=None) -> SampledField or Tensor:
+def native_call(f, *inputs, channels_last=None, channel_dim='vector', extrapolation=None) -> Union[SampledField, Tensor]:
     """
     Similar to `phi.math.native_call()`.
 
@@ -457,7 +457,7 @@ def native_call(f, *inputs, channels_last=None, channel_dim='vector', extrapolat
         raise AssertionError("At least one input must be a SampledField.")
 
 
-def data_bounds(loc: SampledField or Tensor) -> Box:
+def data_bounds(loc: Union[SampledField, Tensor]) -> Box:
     if isinstance(loc, SampledField):
         loc = loc.points
     assert isinstance(loc, Tensor), f"loc must be a Tensor or SampledField but got {type(loc)}"
@@ -499,7 +499,7 @@ def center_of_mass(density: SampledField):
     return mean(density.points * density) / mean(density)
 
 
-def pad(grid: GridType, widths: int or tuple or list or dict) -> GridType:
+def pad(grid: GridType, widths: Union[int, tuple, list, dict]) -> GridType:
     """
     Pads a `Grid` using its extrapolation.
 
@@ -580,7 +580,7 @@ def upsample2x(grid: GridType) -> GridType:
         raise ValueError(type(grid))
 
 
-def concat(fields: List[SampledFieldType] or Tuple[SampledFieldType, ...], dim: str or Shape) -> SampledFieldType:
+def concat(fields: Union[List[SampledFieldType], Tuple[SampledFieldType, ...]], dim: Union[str, Shape]) -> SampledFieldType:
     """
     Concatenates the given `SampledField`s along `dim`.
 
@@ -642,7 +642,7 @@ def stack(fields, dim: Shape, dim_bounds: Box = None):
     raise NotImplementedError(type(fields[0]))
 
 
-def assert_close(*fields: SampledField or Tensor or Number,
+def assert_close(*fields: Union[SampledField, Tensor, Number],
                  rel_tolerance: float = 1e-5,
                  abs_tolerance: float = 0,
                  msg: str = "",
@@ -653,7 +653,7 @@ def assert_close(*fields: SampledField or Tensor or Number,
     math.assert_close(*values, rel_tolerance=rel_tolerance, abs_tolerance=abs_tolerance, msg=msg, verbose=verbose)
 
 
-def where(mask: Field or Geometry or float, field_true: Field or float, field_false: Field or float) -> SampledFieldType:
+def where(mask: Union[Field, Geometry, float], field_true: Union[Field, float], field_false: Union[Field, float]) -> SampledFieldType:
     """
     Element-wise where operation.
     Picks the value of `field_true` where `mask=1 / True` and the value of `field_false` where `mask=0 / False`.
@@ -674,7 +674,7 @@ def where(mask: Field or Geometry or float, field_true: Field or float, field_fa
     return field_true.with_values(values)
 
 
-def maximum(f1: Field or Geometry or float, f2: Field or Geometry or float):
+def maximum(f1: Union[Field, Geometry, float], f2: Union[Field, Geometry, float]):
     """
     Element-wise maximum.
     One of the given fields needs to be an instance of `SampledField` and the the result will be sampled at the corresponding points.
@@ -691,7 +691,7 @@ def maximum(f1: Field or Geometry or float, f2: Field or Geometry or float):
     return f1.with_values(math.maximum(f1.values, f2.values))
 
 
-def minimum(f1: Field or Geometry or float, f2: Field or Geometry or float):
+def minimum(f1: Union[Field, Geometry, float], f2: Union[Field, Geometry, float]):
     """
     Element-wise minimum.
     One of the given fields needs to be an instance of `SampledField` and the the result will be sampled at the corresponding points.
@@ -788,9 +788,9 @@ def integrate(field: Field, region: Geometry, **kwargs) -> Tensor:
 
 
 def pack_dims(field: SampledFieldType,
-              dims: Shape or tuple or list or str,
+              dims: Union[Shape, tuple, list, str],
               packed_dim: Shape,
-              pos: int or None = None) -> SampledFieldType:
+              pos: Union[int, None] = None) -> SampledFieldType:
     """
     Currently only supports grids and non-spatial dimensions.
 
@@ -811,7 +811,7 @@ def pack_dims(field: SampledFieldType,
         raise NotImplementedError()
 
 
-def support(field: SampledField, list_dim: Shape or str = instance('nonzero')) -> Tensor:
+def support(field: SampledField, list_dim: Union[Shape, str] = instance('nonzero')) -> Tensor:
     """
     Returns the points at which the field values are non-zero.
 
@@ -825,7 +825,7 @@ def support(field: SampledField, list_dim: Shape or str = instance('nonzero')) -
     return field.points[math.nonzero(field.values, list_dim=list_dim)]
 
 
-def mask(obj: SampledFieldType or Geometry) -> SampledFieldType:
+def mask(obj: Union[SampledFieldType, Geometry]) -> SampledFieldType:
     """
     Returns a `Field` that masks the inside (or non-zero values when `obj` is a grid) of a physical object.
     The mask takes the value 1 inside the object and 0 outside.

--- a/phi/field/_grid.py
+++ b/phi/field/_grid.py
@@ -1,4 +1,4 @@
-from typing import TypeVar, Any, Tuple, List
+from typing import TypeVar, Any, Tuple, List, Union
 
 from phi.math import Solve
 
@@ -19,7 +19,7 @@ class Grid(SampledField):
     Base class for `CenteredGrid` and `StaggeredGrid`.
     """
 
-    def __init__(self, elements: Geometry, values: Tensor, extrapolation: float or Extrapolation, resolution: Shape or int, bounds: Box or float):
+    def __init__(self, elements: Geometry, values: Tensor, extrapolation: Union[float, Extrapolation], resolution: Union[Shape, int], bounds: Union[Box, float]):
         assert isinstance(bounds, Box)
         assert isinstance(resolution, Shape)
         if bounds.size.vector.item_names is None:
@@ -159,9 +159,9 @@ class CenteredGrid(Grid):
     def __init__(self,
                  values: Any = 0.,
                  extrapolation: Any = 0.,
-                 bounds: Box or float = None,
-                 resolution: int or Shape = None,
-                 **resolution_: int or Tensor):
+                 bounds: Union[Box, float] = None,
+                 resolution: Union[int, Shape] = None,
+                 **resolution_: Union[int, Tensor]):
         """
         Args:
             values: Values to use for the grid.
@@ -296,10 +296,10 @@ class StaggeredGrid(Grid):
 
     def __init__(self,
                  values: Any = 0.,
-                 extrapolation: float or Extrapolation = 0,
-                 bounds: Box or float = None,
-                 resolution: Shape or int = None,
-                 **resolution_: int or Tensor):
+                 extrapolation: Union[float, Extrapolation] = 0,
+                 bounds: Union[Box, float] = None,
+                 resolution: Union[Shape, int] = None,
+                 **resolution_: Union[int, Tensor]):
         """
         Args:
             values: Values to use for the grid.
@@ -545,7 +545,7 @@ def _sample_function(f, elements: Geometry):
     return values
 
 
-def _get_bounds(bounds: Box or float or None, resolution: Shape):
+def _get_bounds(bounds: Union[Box, float, None], resolution: Shape):
     if bounds is None:
         return Box(math.const_vec(0, resolution), math.wrap(resolution, channel(vector=resolution.names)))
     if isinstance(bounds, Box):

--- a/phi/field/_mask.py
+++ b/phi/field/_mask.py
@@ -1,4 +1,5 @@
 import warnings
+from typing import Union
 
 from phi import math
 from phi.geom import Geometry
@@ -31,7 +32,7 @@ class SoftGeometryMask(HardGeometryMask):
     """
     Deprecated since version 1.3. Use `phi.field.mask()` or `phi.field.resample()` instead.
     """
-    def __init__(self, geometry: Geometry, balance: Tensor or float = 0.5):
+    def __init__(self, geometry: Geometry, balance: Union[Tensor, float] = 0.5):
         warnings.warn("HardGeometryMask and SoftGeometryMask are deprecated. Use field.mask or field.resample instead.", DeprecationWarning, stacklevel=2)
         super().__init__(geometry)
         self.balance = balance

--- a/phi/field/_point_cloud.py
+++ b/phi/field/_point_cloud.py
@@ -192,12 +192,12 @@ def nonzero(field: SampledField):
     return PointCloud(elements, values=math.tensor(1.), extrapolation=math.extrapolation.ZERO, add_overlapping=False, bounds=field.bounds)
 
 
-def distribute_points(geometries: tuple or list or Geometry or float,
+def distribute_points(geometries: Union[tuple, list, Geometry, float],
                       dim: Shape = instance('points'),
                       points_per_cell: int = 8,
                       center: bool = False,
                       radius: float = None,
-                      extrapolation: float or Extrapolation = math.NAN,
+                      extrapolation: Union[float, Extrapolation] = math.NAN,
                       **domain) -> PointCloud:
     """
     Transforms `Geometry` objects into a PointCloud.

--- a/phi/field/_scene.py
+++ b/phi/field/_scene.py
@@ -6,7 +6,7 @@ import shutil
 import sys
 import warnings
 from os.path import join, isfile, isdir, abspath, expanduser, basename, split
-from typing import Tuple
+from typing import Tuple, Union
 
 import numpy as np
 
@@ -60,9 +60,9 @@ class Scene:
     To list all scenes within a directory, use `Scene.list()`.
     """
 
-    def __init__(self, paths: str or math.Tensor):
+    def __init__(self, paths: Union[str, math.Tensor]):
         self._paths = math.wrap(paths)
-        self._properties: dict or None = None
+        self._properties: Union[dict, None] = None
 
     def __getitem__(self, item):
         return Scene(self._paths[item])
@@ -151,7 +151,7 @@ class Scene:
     def list(parent_directory: str,
              name='sim',
              include_other: bool = False,
-             dim: Shape or None = None) -> 'Scene' or tuple:
+             dim: Union[Shape, None] = None) -> Union['Scene', tuple]:
         """
         Lists all scenes inside the given directory.
 
@@ -179,7 +179,7 @@ class Scene:
             return Scene(paths)
 
     @staticmethod
-    def at(directory: str or tuple or list or math.Tensor or 'Scene', id: int or math.Tensor or None = None) -> 'Scene':
+    def at(directory: Union[str, tuple, list, math.Tensor, 'Scene'], id: Union[int, math.Tensor, None] = None) -> 'Scene':
         """
         Creates a `Scene` for an existing directory.
 
@@ -210,7 +210,7 @@ class Scene:
                 raise IOError(f"There is no scene at '{path}'")
         return Scene(paths)
 
-    def subpath(self, name: str, create=False, create_parent=False) -> str or tuple:
+    def subpath(self, name: str, create=False, create_parent=False) -> Union[str, tuple]:
         """
         Resolves the relative path `name` with this `Scene` as the root folder.
 

--- a/phi/geom/_box.py
+++ b/phi/geom/_box.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Dict, Tuple
+from typing import Dict, Tuple, Union
 
 import numpy as np
 
@@ -80,7 +80,7 @@ class BaseBox(Geometry):  # not a Subwoofer
         bool_inside = math.any(bool_inside, self.shape.instance)  # union for instance dimensions
         return bool_inside
 
-    def approximate_signed_distance(self, location: Tensor or tuple):
+    def approximate_signed_distance(self, location: Union[Tensor, tuple]):
         """
         Computes the signed L-infinity norm (manhattan distance) from the location to the nearest side of the box.
         For an outside location `l` with the closest surface point `s`, the distance is `max(abs(l - s))`.
@@ -137,7 +137,7 @@ class BaseBox(Geometry):  # not a Subwoofer
         from ._transform import rotate
         return rotate(self, angle)
 
-    def scaled(self, factor: float or Tensor) -> 'Geometry':
+    def scaled(self, factor: Union[float, Tensor]) -> 'Geometry':
         return Cuboid(self.center, self.half_size * factor)
 
 
@@ -178,7 +178,7 @@ class Box(BaseBox, metaclass=BoxType):
         >>> Box['x,y', :1, 0:]  # creates a Box with `lower=(-inf, 0)` and `upper=(1, inf)`.
     """
 
-    def __init__(self, lower: Tensor = None, upper: Tensor = None, **size: int or Tensor):
+    def __init__(self, lower: Tensor = None, upper: Tensor = None, **size: Union[int, Tensor]):
         """
         Args:
           lower: physical location of lower corner
@@ -310,8 +310,8 @@ class Cuboid(BaseBox):
 
     def __init__(self,
                  center: Tensor = 0,
-                 half_size: float or Tensor = None,
-                 **size: float or Tensor):
+                 half_size: Union[float, Tensor] = None,
+                 **size: Union[float, Tensor]):
         if half_size is not None:
             assert isinstance(half_size, Tensor), "half_size must be a Tensor"
             assert 'vector' in half_size.shape, f"Cuboid size must have a 'vector' dimension."
@@ -471,7 +471,7 @@ class GridCell(BaseBox):
         resolution = self._resolution.after_gather(gather_dict)
         return GridCell(resolution, bounds[{d: s for d, s in item.items() if d != 'vector'}])
 
-    def __pack_dims__(self, dims: Tuple[str, ...], packed_dim: Shape, pos: int or None, **kwargs) -> 'Cuboid':
+    def __pack_dims__(self, dims: Tuple[str, ...], packed_dim: Shape, pos: Union[int, None], **kwargs) -> 'Cuboid':
         return math.pack_dims(self.center_representation(), dims, packed_dim, pos, **kwargs)
 
     @staticmethod

--- a/phi/geom/_geom.py
+++ b/phi/geom/_geom.py
@@ -1,4 +1,5 @@
 from numbers import Number
+from typing import Union
 
 from phi import math
 from phi.math import Tensor, Shape, EMPTY_SHAPE, non_channel, wrap, shape
@@ -93,7 +94,7 @@ class Geometry:
         """
         raise NotImplementedError(self.__class__)
 
-    def approximate_signed_distance(self, location: Tensor or tuple) -> Tensor:
+    def approximate_signed_distance(self, location: Union[Tensor, tuple]) -> Tensor:
         """
         Computes the approximate distance from location to the surface of the geometry.
         Locations outside return positive values, inside negative values and zero exactly at the boundary.
@@ -115,7 +116,7 @@ class Geometry:
         """
         raise NotImplementedError(self.__class__)
 
-    def approximate_fraction_inside(self, other_geometry: 'Geometry', balance: Tensor or Number = 0.5) -> Tensor:
+    def approximate_fraction_inside(self, other_geometry: 'Geometry', balance: Union[Tensor, Number] = 0.5) -> Tensor:
         """
         Computes the approximate overlap between the geometry and a small other geometry.
         Returns 1.0 if `other_geometry` is fully enclosed in this geometry and 0.0 if there is no overlap.
@@ -251,7 +252,7 @@ class Geometry:
     def __matmul__(self, other):
         return self.at(other)
 
-    def rotated(self, angle: float or Tensor) -> 'Geometry':
+    def rotated(self, angle: Union[float, Tensor]) -> 'Geometry':
         """
         Returns a rotated version of this geometry.
         The geometry is rotated about its center point.
@@ -264,7 +265,7 @@ class Geometry:
         """
         raise NotImplementedError(self.__class__)
 
-    def scaled(self, factor: float or Tensor) -> 'Geometry':
+    def scaled(self, factor: Union[float, Tensor]) -> 'Geometry':
         """
         Scales each individual geometry by `factor`.
         The individual `center` points act as pivots for the operation.
@@ -373,7 +374,7 @@ class _InvertedGeometry(Geometry):
     def sample_uniform(self, *shape: math.Shape) -> Tensor:
         raise NotImplementedError
 
-    def scaled(self, factor: float or Tensor) -> 'Geometry':
+    def scaled(self, factor: Union[float, Tensor]) -> 'Geometry':
         return _InvertedGeometry(self.geometry.scaled(factor))
 
     def __getitem__(self, item: dict):
@@ -393,7 +394,7 @@ class _InvertedGeometry(Geometry):
     def approximate_signed_distance(self, location: Tensor) -> Tensor:
         return -self.geometry.approximate_signed_distance(location)
 
-    def approximate_fraction_inside(self, other_geometry: 'Geometry', balance: Tensor or Number = 0.5) -> Tensor:
+    def approximate_fraction_inside(self, other_geometry: 'Geometry', balance: Union[Tensor, Number] = 0.5) -> Tensor:
         return 1 - self.geometry.approximate_fraction_inside(other_geometry, 1 - balance)
 
     def push(self, positions: Tensor, outward: bool = True, shift_amount: float = 0) -> Tensor:
@@ -446,7 +447,7 @@ class _NoGeometry(Geometry):
     def sample_uniform(self, *shape: math.Shape) -> Tensor:
         raise NotImplementedError
 
-    def scaled(self, factor: float or Tensor) -> 'Geometry':
+    def scaled(self, factor: Union[float, Tensor]) -> 'Geometry':
         return self
 
     def __getitem__(self, item: dict):
@@ -476,7 +477,7 @@ class _NoGeometry(Geometry):
     def lies_inside(self, location):
         return math.zeros(non_channel(location), dtype=bool)
 
-    def approximate_fraction_inside(self, other_geometry: 'Geometry', balance: Tensor or Number = 0.5) -> Tensor:
+    def approximate_fraction_inside(self, other_geometry: 'Geometry', balance: Union[Tensor, Number] = 0.5) -> Tensor:
         return math.zeros(other_geometry.shape)
 
     def at(self, center: Tensor) -> 'Geometry':
@@ -523,7 +524,7 @@ class Point(Geometry):
     def lies_inside(self, location: Tensor) -> Tensor:
         return expand(math.wrap(False), shape(location).without('vector'))
 
-    def approximate_signed_distance(self, location: Tensor or tuple) -> Tensor:
+    def approximate_signed_distance(self, location: Union[Tensor, tuple]) -> Tensor:
         return math.vec_abs(location - self._location)
 
     def push(self, positions: Tensor, outward: bool = True, shift_amount: float = 0) -> Tensor:
@@ -558,7 +559,7 @@ class Point(Geometry):
     def sample_uniform(self, *shape: math.Shape) -> Tensor:
         raise NotImplementedError
 
-    def scaled(self, factor: float or Tensor) -> 'Geometry':
+    def scaled(self, factor: Union[float, Tensor]) -> 'Geometry':
         return self
 
     def __getitem__(self, item):

--- a/phi/geom/_sphere.py
+++ b/phi/geom/_sphere.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 from phi import math
 from ._geom import Geometry, _keep_vector
 from ..math import wrap, Tensor, expand
@@ -12,8 +14,8 @@ class Sphere(Geometry):
 
     def __init__(self,
                  center: Tensor = None,
-                 radius: float or Tensor = None,
-                 **center_: float or Tensor):
+                 radius: Union[float, Tensor] = None,
+                 **center_: Union[float, Tensor]):
         """
         Args:
             center: Sphere center as `Tensor` with `vector` dimension.
@@ -67,7 +69,7 @@ class Sphere(Geometry):
         distance_squared = math.sum((location - self.center) ** 2, dim='vector')
         return math.any(distance_squared <= self.radius ** 2, self.shape.instance)  # union for instance dimensions
 
-    def approximate_signed_distance(self, location: Tensor or tuple):
+    def approximate_signed_distance(self, location: Union[Tensor, tuple]):
         """
         Computes the exact distance from location to the closest point on the sphere.
         Very close to the sphere center, the distance takes a constant value.
@@ -99,7 +101,7 @@ class Sphere(Geometry):
     def rotated(self, angle):
         return self
 
-    def scaled(self, factor: float or Tensor) -> 'Geometry':
+    def scaled(self, factor: Union[float, Tensor]) -> 'Geometry':
         return Sphere(self.center, self.radius * factor)
 
     def __variable_attrs__(self):

--- a/phi/geom/_transform.py
+++ b/phi/geom/_transform.py
@@ -1,5 +1,5 @@
 from numbers import Number
-from typing import Tuple
+from typing import Tuple, Union
 
 from phi import math
 from phi.math import Tensor, Shape
@@ -11,7 +11,7 @@ from ..math._shape import parse_dim_order
 
 class RotatedGeometry(Geometry):
 
-    def __init__(self, geometry: Geometry, angle: float or math.Tensor):
+    def __init__(self, geometry: Geometry, angle: Union[float, math.Tensor]):
         assert not isinstance(geometry, RotatedGeometry)
         self._geometry = geometry
         self._angle = math.wrap(angle)
@@ -83,7 +83,7 @@ class RotatedGeometry(Geometry):
     def rotated(self, angle) -> Geometry:
         return RotatedGeometry(self._geometry, self._angle + angle)
 
-    def scaled(self, factor: float or Tensor) -> 'Geometry':
+    def scaled(self, factor: Union[float, Tensor]) -> 'Geometry':
         return RotatedGeometry(self._geometry.scaled(factor), self._angle)
 
     def unstack(self, dimension: str) -> tuple:
@@ -100,7 +100,7 @@ class RotatedGeometry(Geometry):
         return f"rot({self._geometry}, angle={self._angle})"
 
 
-def rotate(geometry: Geometry, angle: Number or Tensor) -> Geometry:
+def rotate(geometry: Geometry, angle: Union[Number, Tensor]) -> Geometry:
     """ Package-internal rotation function. Users should use Geometry.rotated() instead. """
     assert isinstance(geometry, Geometry)
     if isinstance(geometry, RotatedGeometry):
@@ -173,17 +173,17 @@ class _EmbeddedGeometry(Geometry):
     def at(self, center: Tensor) -> 'Geometry':
         raise NotImplementedError()
 
-    def rotated(self, angle: float or Tensor) -> 'Geometry':
+    def rotated(self, angle: Union[float, Tensor]) -> 'Geometry':
         raise NotImplementedError()
 
-    def scaled(self, factor: float or Tensor) -> 'Geometry':
+    def scaled(self, factor: Union[float, Tensor]) -> 'Geometry':
         raise NotImplementedError()
 
     def __hash__(self):
         return hash(self.geometry) + hash(self.axes)
 
 
-def embed(geometry: Geometry, projected_dims: math.Shape or str or tuple or list or None) -> Geometry:
+def embed(geometry: Geometry, projected_dims: Union[math.Shape, str, tuple, list, None]) -> Geometry:
     """
     Adds fake spatial dimensions to a geometry.
     The geometry value will be constant along the added dimensions, as if it had infinite length in these directions.
@@ -212,7 +212,7 @@ def embed(geometry: Geometry, projected_dims: math.Shape or str or tuple or list
     return _EmbeddedGeometry(geometry, axes)
 
 
-def infinite_cylinder(center=None, radius=None, inf_dim: str or Shape or tuple or list = None, **center_) -> Geometry:
+def infinite_cylinder(center=None, radius=None, inf_dim: Union[str, Shape, tuple, list] = None, **center_) -> Geometry:
     """
     Creates an infinite cylinder.
     This is equal to embedding an `n`-dimensional `Sphere` in `n+1` dimensions.

--- a/phi/jax/_jax_backend.py
+++ b/phi/jax/_jax_backend.py
@@ -1,7 +1,7 @@
 import numbers
 import warnings
 from functools import wraps
-from typing import List, Callable, Tuple
+from typing import List, Callable, Tuple, Union
 from packaging import version
 
 import jax
@@ -178,7 +178,7 @@ class JaxBackend(Backend):
             for v in values:
                 self.block_until_ready(v)
 
-    def jacobian(self, f, wrt: tuple or list, get_output: bool, is_f_scalar: bool):
+    def jacobian(self, f, wrt: Union[tuple, list], get_output: bool, is_f_scalar: bool):
         if get_output:
             jax_grad_f = jax.value_and_grad(f, argnums=wrt, has_aux=True)
             @wraps(f)
@@ -213,7 +213,7 @@ class JaxBackend(Backend):
         return jnp.where(y == 0, 0, x / y)
         # jnp.nan_to_num(x / y, copy=True, nan=0) covers up NaNs from before
 
-    def random_uniform(self, shape, low, high, dtype: DType or None):
+    def random_uniform(self, shape, low, high, dtype: Union[DType, None]):
         self._check_float64()
         self.rnd_key, subkey = jax.random.split(self.rnd_key)
 
@@ -301,7 +301,7 @@ class JaxBackend(Backend):
     def mean(self, value, axis=None, keepdims=False):
         return jnp.mean(value, axis, keepdims=keepdims)
 
-    def tensordot(self, a, a_axes: tuple or list, b, b_axes: tuple or list):
+    def tensordot(self, a, a_axes: Union[tuple, list], b, b_axes: Union[tuple, list]):
         return jnp.tensordot(a, b, (a_axes, b_axes))
 
     def mul(self, a, b):
@@ -322,7 +322,7 @@ class JaxBackend(Backend):
         result = jnp.diagonal(matrices, offset=offset, axis1=1, axis2=2)
         return jnp.transpose(result, [0, 2, 1])
 
-    def while_loop(self, loop: Callable, values: tuple, max_iter: int or Tuple[int, ...] or List[int]):
+    def while_loop(self, loop: Callable, values: tuple, max_iter: Union[int, Tuple[int, ...], List[int]]):
         if all(self.is_available(t) for t in values):
             return self.stop_gradient_tree(Backend.while_loop(self, loop, values, max_iter))
         if isinstance(max_iter, (tuple, list)):  # stack traced trajectory, unroll until max_iter
@@ -432,7 +432,7 @@ class JaxBackend(Backend):
     def quantile(self, x, quantiles):
         return jnp.quantile(x, quantiles, axis=-1)
 
-    def fft(self, x, axes: tuple or list):
+    def fft(self, x, axes: Union[tuple, list]):
         x = self.to_complex(x)
         if not axes:
             return x
@@ -443,7 +443,7 @@ class JaxBackend(Backend):
         else:
             return jnp.fft.fftn(x, axes=axes).astype(x.dtype)
 
-    def ifft(self, k, axes: tuple or list):
+    def ifft(self, k, axes: Union[tuple, list]):
         if not axes:
             return k
         if len(axes) == 1:
@@ -473,7 +473,7 @@ class JaxBackend(Backend):
         x = jax.lax.linalg.triangular_solve(matrix, rhs, lower=lower, unit_diagonal=unit_diagonal, left_side=True)
         return x
 
-    def sparse_coo_tensor(self, indices: tuple or list, values, shape: tuple):
+    def sparse_coo_tensor(self, indices: Union[tuple, list], values, shape: tuple):
         return BCOO((values, indices), shape=shape)
 
 

--- a/phi/jax/stax/nets.py
+++ b/phi/jax/stax/nets.py
@@ -7,7 +7,7 @@ For API documentation, see https://tum-pbs.github.io/PhiFlow/Network_API .
 import functools
 import inspect
 import warnings
-from typing import Callable, Tuple, List
+from typing import Callable, Tuple, List, Union
 
 import numpy
 import jax
@@ -176,7 +176,7 @@ def _recursive_add_parameters(param, wrap: bool, prefix: tuple, result: dict):
             result[name] = phi_tensor
 
 
-def save_state(obj: StaxNet or JaxOptimizer, path: str):
+def save_state(obj: Union[StaxNet, JaxOptimizer], path: str):
     """
     Write the state of a module or optimizer to a file.
 
@@ -196,7 +196,7 @@ def save_state(obj: StaxNet or JaxOptimizer, path: str):
         # numpy.save(path, obj._state)
 
 
-def load_state(obj: StaxNet or JaxOptimizer, path: str):
+def load_state(obj: Union[StaxNet, JaxOptimizer], path: str):
     """
     Read the state of a module or optimizer from a file.
 
@@ -285,7 +285,7 @@ def rmsprop(net: StaxNet, learning_rate: float = 1e-3, alpha=0.99, eps=1e-08, we
 
 def dense_net(in_channels: int,
               out_channels: int,
-              layers: Tuple[int, ...] or List[int],
+              layers: Union[Tuple[int, ...], List[int]],
               batch_norm=False,
               activation='ReLU',
               softmax=False) -> StaxNet:
@@ -320,10 +320,10 @@ def dense_net(in_channels: int,
 def u_net(in_channels: int,
           out_channels: int,
           levels: int = 4,
-          filters: int or tuple or list = 16,
+          filters: Union[int, tuple, list] = 16,
           batch_norm: bool = True,
           activation='ReLU',
-          in_spatial: tuple or int = 2,
+          in_spatial: Union[tuple, int] = 2,
           periodic=False,
           use_res_blocks: bool = False) -> StaxNet:
     """
@@ -469,7 +469,7 @@ def create_upsample():
 
 
 def conv_classifier(in_features: int,
-                    in_spatial: tuple or list,
+                    in_spatial: Union[tuple, list],
                     num_classes: int,
                     blocks=(64, 128, 256, 256, 512, 512),
                     dense_layers=(4096, 4096, 100),
@@ -545,11 +545,11 @@ def conv_classifier(in_features: int,
 
 def conv_net(in_channels: int,
              out_channels: int,
-             layers: Tuple[int, ...] or List[int],
+             layers: Union[Tuple[int, ...], List[int]],
              batch_norm: bool = False,
-             activation: str or Callable = 'ReLU',
+             activation: Union[str, Callable] = 'ReLU',
              periodic=False,
-             in_spatial: int or tuple = 2) -> StaxNet:
+             in_spatial: Union[int, tuple] = 2) -> StaxNet:
     """
     Built in Conv-Nets are also provided. Contrary to the classical convolutional neural networks, the feature map spatial size remains the same throughout the layers. Each layer of the network is essentially a convolutional block comprising of two conv layers. A filter size of 3 is used in the convolutional layers.
     Arguments:
@@ -616,11 +616,11 @@ def conv_net(in_channels: int,
 
 def res_net(in_channels: int,
             out_channels: int,
-            layers: Tuple[int, ...] or List[int],
+            layers: Union[Tuple[int, ...], List[int]],
             batch_norm: bool = False,
-            activation: str or Callable = 'ReLU',
+            activation: Union[str, Callable] = 'ReLU',
             periodic=False,
-            in_spatial: int or tuple = 2) -> StaxNet:
+            in_spatial: Union[int, tuple] = 2) -> StaxNet:
     """
     Built in Res-Nets are provided in the ΦFlow framework. Similar to the conv-net, the feature map spatial size remains the same throughout the layers.
     These networks use residual blocks composed of two conv layers with a skip connection added from the input to the output feature map.
@@ -666,8 +666,8 @@ def resnet_block(in_channels: int,
                  out_channels: int,
                  periodic: bool,
                  batch_norm: bool,
-                 activation: str or Callable = 'ReLU',
-                 d: int or tuple = 2):
+                 activation: Union[str, Callable] = 'ReLU',
+                 d: Union[int, tuple] = 2):
     activation = ACTIVATIONS[activation] if isinstance(activation, str) else activation
     init_fn, apply_fn = {}, {}
     init_fn['conv1'], apply_fn['conv1'] = stax.serial(
@@ -757,7 +757,7 @@ def get_mask(inputs, reverse_mask, data_format='NHWC'):
 def Dense_resnet_block(in_channels: int,
                        mid_channels: int,
                        batch_norm: bool = False,
-                       activation: str or Callable = 'ReLU'):
+                       activation: Union[str, Callable] = 'ReLU'):
     inputs = keras.Input(shape=(in_channels,))
     x_1 = inputs
 
@@ -795,11 +795,11 @@ def Dense_resnet_block(in_channels: int,
 
 def conv_net_unit(in_channels: int,
                   out_channels: int,
-                  layers: Tuple[int, ...] or List[int, ...],
+                  layers: Union[Tuple[int, ...], List[int, ...]],
                   periodic: bool = False,
                   batch_norm: bool = False,
-                  activation: str or Callable = 'ReLU',
-                  in_spatial: int or tuple = 2, **kwargs):
+                  activation: Union[str, Callable] = 'ReLU',
+                  in_spatial: Union[int, tuple] = 2, **kwargs):
     """ Conv-net unit for Invertible Nets"""
     if isinstance(in_spatial, int):
         d = in_spatial
@@ -863,11 +863,11 @@ def conv_net_unit(in_channels: int,
 def u_net_unit(in_channels: int,
                out_channels: int,
                levels: int = 4,
-               filters: int or tuple or list = 16,
+               filters: Union[int, tuple, list] = 16,
                batch_norm: bool = True,
                activation='ReLU',
                periodic=False,
-               in_spatial: tuple or int = 2,
+               in_spatial: Union[tuple, int] = 2,
                use_res_blocks: bool = False, **kwargs):
     """ U-net unit for Invertible Nets"""
     if isinstance(filters, (tuple, list)):
@@ -936,11 +936,11 @@ def u_net_unit(in_channels: int,
 
 def res_net_unit(in_channels: int,
                  out_channels: int,
-                 layers: Tuple[int, ...] or List[int],
+                 layers: Union[Tuple[int, ...], List[int]],
                  batch_norm: bool = False,
-                 activation: str or Callable = 'ReLU',
+                 activation: Union[str, Callable] = 'ReLU',
                  periodic=False,
-                 in_spatial: int or tuple = 2, **kwargs):
+                 in_spatial: Union[int, tuple] = 2, **kwargs):
     """ Res-net unit for Invertible Nets"""
     if isinstance(in_spatial, int):
         d = in_spatial
@@ -962,9 +962,9 @@ NET = {'u_net': u_net_unit, 'res_net': res_net_unit, 'conv_net': conv_net_unit}
 
 
 def coupling_layer(in_channels: int,
-                   activation: str or Callable = 'ReLU',
+                   activation: Union[str, Callable] = 'ReLU',
                    batch_norm: bool = False,
-                   in_spatial: int or tuple = 2,
+                   in_spatial: Union[int, tuple] = 2,
                    net: str = 'u_net',
                    reverse_mask: bool = False,
                    **kwargs):
@@ -1045,8 +1045,8 @@ def invertible_net(in_channels: int,
                    num_blocks: int,
                    batch_norm: bool = False,
                    net: str = 'u_net',
-                   activation: str or type = 'ReLU',
-                   in_spatial: tuple or int = 2, **kwargs):
+                   activation: Union[str, type] = 'ReLU',
+                   in_spatial: Union[tuple, int] = 2, **kwargs):
     """
     ΦFlow also provides invertible neural networks that are capable of inverting the output tensor back to the input tensor initially passed.\ These networks have far reaching applications in predicting input parameters of a problem given its observations.\ Invertible nets are composed of multiple concatenated coupling blocks wherein each such block consists of arbitrary neural networks.
 

--- a/phi/math/_functional.py
+++ b/phi/math/_functional.py
@@ -2,7 +2,7 @@ import inspect
 import types
 import warnings
 from functools import wraps, partial
-from typing import Tuple, Callable, Dict, Generic, List, TypeVar, Any, Set
+from typing import Tuple, Callable, Dict, Generic, List, TypeVar, Any, Set, Union
 
 import numpy as np
 
@@ -23,10 +23,10 @@ Y = TypeVar('Y')
 class SignatureKey:
 
     def __init__(self,
-                 source_function: Callable or None,
+                 source_function: Union[Callable, None],
                  tree: Dict[str, Any],
-                 shapes: Shape or Tuple[Shape],
-                 specs: Tuple[Shape] or None,
+                 shapes: Union[Shape, Tuple[Shape]],
+                 specs: Union[Tuple[Shape], None],
                  backend: Backend,
                  tracing: bool,
                  condition: Any = None):
@@ -409,7 +409,7 @@ def jit_compile_linear(f: Callable[[X], Y] = None, auxiliary_args: str = None, f
     return f if isinstance(f, LinearFunction) and f.auxiliary_args == auxiliary_args else LinearFunction(f, auxiliary_args, forget_traces or False)
 
 
-def simplify_wrt(f, wrt: str or int or tuple or list):
+def simplify_wrt(f, wrt: Union[str, int, tuple, list]):
     f_params = function_parameters(f)
     if wrt is None:  # Old default
         wrt = f_params[0],
@@ -434,7 +434,7 @@ def simplify_wrt(f, wrt: str or int or tuple or list):
 class GradientFunction:
     """ Jacobian or Gradient of a function. """
 
-    def __init__(self, f: Callable, f_params, wrt: str or Tuple[str, ...], get_output: bool, is_f_scalar: bool, jit=False):
+    def __init__(self, f: Callable, f_params, wrt: Union[str, Tuple[str, ...]], get_output: bool, is_f_scalar: bool, jit=False):
         self.f = f
         self.f_params = f_params
         self.wrt = wrt
@@ -962,7 +962,7 @@ def trace_check(f, *args, **kwargs):
     return True
 
 
-def map_types(f: Callable, dims: Shape or tuple or list or str or Callable, dim_type: Callable or str) -> Callable:
+def map_types(f: Callable, dims: Union[Shape, tuple, list, str, Callable], dim_type: Union[Callable, str]) -> Callable:
     """
     Wraps a function to change the dimension types of its `Tensor` and `phi.math.magic.PhiTreeNode` arguments.
 
@@ -1021,7 +1021,7 @@ def map_i2b(f: Callable) -> Callable:
 
 
 def iterate(f: Callable,
-            iterations: int or Shape,
+            iterations: Union[int, Shape],
             *x0,
             f_kwargs: dict = None,
             range: Callable = range,

--- a/phi/math/_magic_ops.py
+++ b/phi/math/_magic_ops.py
@@ -108,7 +108,7 @@ def _any_uniform_dim(dims: Shape):
     raise ValueError(f"Uniform dimension required but found only non-uniform dimensions {dims}")
 
 
-def stack(values: tuple or list or dict, dim: Shape, expand_values=False, **kwargs):
+def stack(values: Union[tuple, list, dict], dim: Shape, expand_values=False, **kwargs):
     """
     Stacks `values` along the new dimension `dim`.
     All values must have the same spatial, instance and channel dimensions. If the dimension sizes vary, the resulting tensor will be non-uniform.
@@ -233,7 +233,7 @@ def stack(values: tuple or list or dict, dim: Shape, expand_values=False, **kwar
         return values[0]
 
 
-def concat(values: tuple or list, dim: str or Shape, **kwargs):
+def concat(values: Union[tuple, list], dim: Union[str, Shape], **kwargs):
     """
     Concatenates a sequence of `phi.math.magic.Shapable` objects, e.g. `Tensor`, along one dimension.
     All values must have the same spatial, instance and channel dimensions and their sizes must be equal, except for `dim`.
@@ -419,7 +419,7 @@ def rename_dims(value,
     return value
 
 
-def pack_dims(value, dims: DimFilter, packed_dim: Shape, pos: int or None = None, **kwargs):
+def pack_dims(value, dims: DimFilter, packed_dim: Shape, pos: Union[int, None] = None, **kwargs):
     """
     Compresses multiple dimensions into a single dimension by concatenating the elements.
     Elements along the new dimensions are laid out according to the order of `dims`.
@@ -477,7 +477,7 @@ def pack_dims(value, dims: DimFilter, packed_dim: Shape, pos: int or None = None
 
 
 
-def unpack_dim(value, dim: str or Shape, *unpacked_dims: Shape, **kwargs):
+def unpack_dim(value, dim: Union[str, Shape], *unpacked_dims: Shape, **kwargs):
     """
     Decompresses a dimension by unstacking the elements along it.
     This function replaces the traditional `reshape` for these cases.
@@ -651,7 +651,7 @@ MagicType = TypeVar('MagicType')
 OtherMagicType = TypeVar('OtherMagicType')
 
 
-def cast(x: MagicType, dtype: DType or type) -> OtherMagicType:
+def cast(x: MagicType, dtype: Union[DType, type]) -> OtherMagicType:
     """
     Casts `x` to a different data type.
 

--- a/phi/math/_nd.py
+++ b/phi/math/_nd.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Tuple, Optional, List
+from typing import Tuple, Optional, List, Union
 
 import numpy as np
 
@@ -14,7 +14,7 @@ from ._functional import jit_compile_linear
 from ._optimize import solve_linear
 
 
-def vec(name: str or Shape = 'vector', *sequence, tuple_dim=spatial('sequence'), list_dim=instance('sequence'), **components) -> Tensor:
+def vec(name: Union[str, Shape] = 'vector', *sequence, tuple_dim=spatial('sequence'), list_dim=instance('sequence'), **components) -> Tensor:
     """
     Lay out the given values along a channel dimension without converting them to the current backend.
 
@@ -66,7 +66,7 @@ def vec(name: str or Shape = 'vector', *sequence, tuple_dim=spatial('sequence'),
         return stack(components, dim, expand_values=True)
 
 
-def const_vec(value: float or Tensor, dim: Shape or tuple or list or str):
+def const_vec(value: Union[float, Tensor], dim: Union[Shape, tuple, list, str]):
     """
     Creates a single-dimension tensor with all values equal to `value`.
     `value` is not converted to the default backend, even when it is a Python primitive.
@@ -92,7 +92,7 @@ def const_vec(value: float or Tensor, dim: Shape or tuple or list or str):
     return wrap([value] * shape.size, shape)
 
 
-def vec_abs(vec: Tensor, vec_dim: DimFilter = channel, eps: float or Tensor = None):
+def vec_abs(vec: Tensor, vec_dim: DimFilter = channel, eps: Union[float, Tensor] = None):
     """
     Computes the vector length of `vec`.
 
@@ -146,7 +146,7 @@ def cross_product(vec1: Tensor, vec2: Tensor) -> Tensor:
         raise AssertionError(f'dims = {spatial_rank}. Vector product not available in > 3 dimensions')
 
 
-def rotate_vector(vector: math.Tensor, angle: float or math.Tensor) -> Tensor:
+def rotate_vector(vector: math.Tensor, angle: Union[float, math.Tensor]) -> Tensor:
     """
     Rotates `vector` around the origin.
 
@@ -171,7 +171,7 @@ def rotate_vector(vector: math.Tensor, angle: float or math.Tensor) -> Tensor:
         raise NotImplementedError(f"Rotation in {vector.vector.size}D not yet implemented.")
 
 
-def dim_mask(all_dims: Shape or tuple or list, dims: DimFilter, mask_dim=channel('vector')) -> Tensor:
+def dim_mask(all_dims: Union[Shape, tuple, list], dims: DimFilter, mask_dim=channel('vector')) -> Tensor:
     """
     Creates a masked vector with 1 elements for `dims` and 0 for all other dimensions in `all_dims`.
 
@@ -193,7 +193,7 @@ def dim_mask(all_dims: Shape or tuple or list, dims: DimFilter, mask_dim=channel
     return wrap(mask, mask_dim)
 
 
-def normalize_to(target: Tensor, source: float or Tensor, epsilon=1e-5):
+def normalize_to(target: Tensor, source: Union[float, Tensor], epsilon=1e-5):
     """
     Multiplies the target so that its sum matches the source.
 
@@ -361,7 +361,7 @@ def abs_square(complex_values: Tensor) -> Tensor:
 def shift(x: Tensor,
           offsets: tuple,
           dims: DimFilter = math.spatial,
-          padding: Extrapolation or Tensor or float or None = extrapolation.BOUNDARY,
+          padding: Union[Extrapolation, Tensor, float, None] = extrapolation.BOUNDARY,
           stack_dim: Optional[Shape] = channel('shift'),
           extend_bounds=0) -> list:
     """
@@ -477,11 +477,11 @@ def finite_fill(values: Tensor, dims: DimFilter = spatial, distance: int = 1, di
 # Gradient
 
 def spatial_gradient(grid: Tensor,
-                     dx: float or Tensor = 1,
+                     dx: Union[float, Tensor] = 1,
                      difference: str = 'central',
-                     padding: Extrapolation or None = extrapolation.BOUNDARY,
+                     padding: Union[Extrapolation, None] = extrapolation.BOUNDARY,
                      dims: DimFilter = spatial,
-                     stack_dim: Shape or None = channel('gradient'),
+                     stack_dim: Union[Shape, None] = channel('gradient'),
                      pad=0) -> Tensor:
     """
     Calculates the spatial_gradient of a scalar channel from finite differences.
@@ -527,7 +527,7 @@ def spatial_gradient(grid: Tensor,
 # Laplace
 
 def laplace(x: Tensor,
-            dx: Tensor or float = 1,
+            dx: Union[Tensor, float] = 1,
             padding: Extrapolation = extrapolation.BOUNDARY,
             dims: DimFilter = spatial,
             weights: Tensor = None):
@@ -564,7 +564,7 @@ def laplace(x: Tensor,
 
 
 def fourier_laplace(grid: Tensor,
-                    dx: Tensor or Shape or float or list or tuple,
+                    dx: Union[Tensor, Shape, float, list, tuple],
                     times: int = 1):
     """
     Applies the spatial laplace operator to the given tensor with periodic boundary conditions.
@@ -594,7 +594,7 @@ def fourier_laplace(grid: Tensor,
 
 
 def fourier_poisson(grid: Tensor,
-                    dx: Tensor or Shape or float or list or tuple,
+                    dx: Union[Tensor, Shape, float, list, tuple],
                     times: int = 1):
     """
     Inverse operation to `fourier_laplace`.

--- a/phi/math/_ops.py
+++ b/phi/math/_ops.py
@@ -2,7 +2,7 @@ import functools
 import math
 import warnings
 from numbers import Number
-from typing import Tuple, Callable, Any
+from typing import Tuple, Callable, Any, Union
 
 import numpy as np
 
@@ -101,7 +101,7 @@ def seed(seed: int):
     random.seed(0)
 
 
-def native(value: Tensor or Number or tuple or list or Any):
+def native(value: Union[Tensor, Number, tuple, list, Any]):
     """
     Returns the native tensor representation of `value`.
     If `value` is a `phi.math.Tensor`, this is equal to calling `phi.math.Tensor.native()`.
@@ -123,7 +123,7 @@ def native(value: Tensor or Number or tuple or list or Any):
         return value
 
 
-def numpy(value: Tensor or Number or tuple or list or Any):
+def numpy(value: Union[Tensor, Number, tuple, list, Any]):
     """
     Converts `value` to a `numpy.ndarray` where value must be a `Tensor`, backend tensor or tensor-like.
     If `value` is a `phi.math.Tensor`, this is equal to calling `phi.math.Tensor.numpy()`.
@@ -150,7 +150,7 @@ def numpy(value: Tensor or Number or tuple or list or Any):
 
 
 def reshaped_native(value: Tensor,
-                    groups: tuple or list,
+                    groups: Union[tuple, list],
                     force_expand: Any = False,
                     to_numpy=False):
     """
@@ -194,7 +194,7 @@ def reshaped_native(value: Tensor,
     return value.numpy(order) if to_numpy else value.native(order)
 
 
-def reshaped_numpy(value: Tensor, groups: tuple or list, force_expand: Any = False):
+def reshaped_numpy(value: Tensor, groups: Union[tuple, list], force_expand: Any = False):
     """
     Returns the NumPy representation of `value` where dimensions are laid out according to `groups`.
 
@@ -216,7 +216,7 @@ def reshaped_numpy(value: Tensor, groups: tuple or list, force_expand: Any = Fal
 
 
 def reshaped_tensor(value: Any,
-                    groups: tuple or list,
+                    groups: Union[tuple, list],
                     check_sizes=False,
                     convert=True):
     """
@@ -328,7 +328,7 @@ def native_call(f: Callable, *inputs: Tensor, channels_last=None, channel_dim='v
         return result
 
 
-def print_(obj: Tensor or PhiTreeNode or Number or tuple or list or None = None, name: str = ""):
+def print_(obj: Union[Tensor, PhiTreeNode, Number, tuple, list, None] = None, name: str = ""):
     """
     Print a tensor with no more than two spatial dimensions, slicing it along all batch and channel dimensions.
     
@@ -366,7 +366,7 @@ def print_(obj: Tensor or PhiTreeNode or Number or tuple or list or None = None,
         print(f"{wrap(obj):full}")
 
 
-def map_(function, *values, range=range, **kwargs) -> Tensor or None:
+def map_(function, *values, range=range, **kwargs) -> Union[Tensor, None]:
     """
     Calls `function` on all elements of `values`.
 
@@ -438,7 +438,7 @@ def zeros(*shape: Shape, dtype=None) -> Tensor:
     return _initialize(lambda shape: expand_tensor(NativeTensor(default_backend().zeros((), dtype=DType.as_dtype(dtype)), EMPTY_SHAPE), shape), shape)
 
 
-def zeros_like(obj: Tensor or PhiTreeNode) -> Tensor or PhiTreeNode:
+def zeros_like(obj: Union[Tensor, PhiTreeNode]) -> Union[Tensor, PhiTreeNode]:
     """ Create a `Tensor` containing only `0.0` / `0` / `False` with the same shape and dtype as `obj`. """
     nest, values = disassemble_tree(obj)
     zeros_ = []
@@ -500,9 +500,9 @@ def random_normal(*shape: Shape, dtype=None) -> Tensor:
 
 
 def random_uniform(*shape: Shape,
-                   low: Tensor or float = 0,
-                   high: Tensor or float = 1,
-                   dtype: DType or tuple = None) -> Tensor:
+                   low: Union[Tensor, float] = 0,
+                   high: Union[Tensor, float] = 1,
+                   dtype: Union[DType, tuple] = None) -> Tensor:
     """
     Creates a `Tensor` with the specified shape, filled with random values sampled from a uniform distribution.
 
@@ -573,7 +573,7 @@ def cumulative_sum(x: Tensor, dim: DimFilter):
     return NativeTensor(native_result, x.shape)
 
 
-def fftfreq(resolution: Shape, dx: Tensor or float = 1, dtype: DType = None):
+def fftfreq(resolution: Shape, dx: Union[Tensor, float] = 1, dtype: DType = None):
     """
     Returns the discrete Fourier transform sample frequencies.
     These are the frequencies corresponding to the components of the result of `math.fft` on a tensor of shape `resolution`.
@@ -591,7 +591,7 @@ def fftfreq(resolution: Shape, dx: Tensor or float = 1, dtype: DType = None):
     return to_float(k) if dtype is None else cast(k, dtype)
 
 
-def meshgrid(dim_type=spatial, stack_dim=channel('vector'), assign_item_names=True, **dimensions: int or Tensor) -> Tensor:
+def meshgrid(dim_type=spatial, stack_dim=channel('vector'), assign_item_names=True, **dimensions: Union[int, Tensor]) -> Tensor:
     """
     Generate a mesh-grid `Tensor` from keyword dimensions.
 
@@ -632,7 +632,7 @@ def meshgrid(dim_type=spatial, stack_dim=channel('vector'), assign_item_names=Tr
         return stack_tensors(channels, stack_dim)
 
 
-def linspace(start: int or Tensor, stop, dim: Shape) -> Tensor:
+def linspace(start: Union[int, Tensor], stop, dim: Shape) -> Tensor:
     """
     Returns `number` evenly spaced numbers between `start` and `stop`.
 
@@ -668,7 +668,7 @@ def linspace(start: int or Tensor, stop, dim: Shape) -> Tensor:
         return map_(linspace, start, stop, dim=dim)
 
 
-def arange(dim: Shape, start_or_stop: int or None = None, stop: int or None = None, step=1):
+def arange(dim: Shape, start_or_stop: Union[int, None] = None, stop: Union[int, None] = None, step=1):
     """
     Returns evenly spaced values between `start` and `stop`.
     If only one limit is given, `0` is used for the start.
@@ -717,7 +717,7 @@ def range_tensor(*shape: Shape):
     return unpack_dim(data, 'range', shape)
 
 
-def stack_tensors(values: tuple or list, dim: Shape):
+def stack_tensors(values: Union[tuple, list], dim: Shape):
     if len(values) == 1 and not dim:
         return values[0]
     values = [wrap(v) for v in values]
@@ -733,7 +733,7 @@ def stack_tensors(values: tuple or list, dim: Shape):
     return result
 
 
-def concat_tensor(values: tuple or list, dim: str) -> Tensor:
+def concat_tensor(values: Union[tuple, list], dim: str) -> Tensor:
     assert len(values) > 0, "concat() got empty sequence"
     assert isinstance(dim, str), f"dim must be a single-dimension Shape but got '{dim}' of type {type(dim)}"
 
@@ -752,7 +752,7 @@ def concat_tensor(values: tuple or list, dim: str) -> Tensor:
     return result
 
 
-def pad(value: Tensor, widths: dict, mode: 'e_.Extrapolation' or Tensor or Number, **kwargs) -> Tensor:
+def pad(value: Tensor, widths: dict, mode: Union['e_.Extrapolation', Tensor, Number], **kwargs) -> Tensor:
     """
     Pads a tensor along the specified dimensions, determining the added values using the given extrapolation.
     Unlike `Extrapolation.pad()`, this function can handle negative widths which slice off outer values.
@@ -866,7 +866,7 @@ def grid_sample(grid: Tensor, coordinates: Tensor, extrap: 'e_.Extrapolation', *
     return result
 
 
-def _grid_sample(grid: Tensor, coordinates: Tensor, extrap: 'e_.Extrapolation' or None, pad_kwargs: dict):
+def _grid_sample(grid: Tensor, coordinates: Tensor, extrap: Union['e_.Extrapolation', None], pad_kwargs: dict):
     if grid.shape.batch == coordinates.shape.batch or grid.shape.batch.volume == 1 or coordinates.shape.batch.volume == 1:
         # call backend.grid_sample()
         batch = grid.shape.batch & coordinates.shape.batch
@@ -907,8 +907,8 @@ def _grid_sample(grid: Tensor, coordinates: Tensor, extrap: 'e_.Extrapolation' o
 
 
 def broadcast_op(operation: Callable,
-                 tensors: tuple or list,
-                 iter_dims: set or tuple or list or Shape = None,
+                 tensors: Union[tuple, list],
+                 iter_dims: Union[set, tuple, list, Shape] = None,
                  no_return=False):
     if iter_dims is None:
         iter_dims = set()
@@ -947,7 +947,7 @@ def broadcast_op(operation: Callable,
             return TensorStack(result_unstacked, Shape((None,), (dim,), (dim_type,), (item_names,)))
 
 
-def where(condition: Tensor or float or int, value_true: Tensor or float or int, value_false: Tensor or float or int):
+def where(condition: Union[Tensor, float, int], value_true: Union[Tensor, float, int], value_false: Union[Tensor, float, int]):
     """
     Builds a tensor by choosing either values from `value_true` or `value_false` depending on `condition`.
     If `condition` is not of type boolean, non-zero values are interpreted as True.
@@ -977,7 +977,7 @@ def where(condition: Tensor or float or int, value_true: Tensor or float or int,
     return broadcast_op(inner_where, [condition, value_true, value_false])
 
 
-def nonzero(value: Tensor, list_dim: Shape or str = instance('nonzero'), index_dim: Shape = channel('vector')):
+def nonzero(value: Tensor, list_dim: Union[Shape, str] = instance('nonzero'), index_dim: Shape = channel('vector')):
     """
     Get spatial indices of non-zero / True values.
     
@@ -1040,7 +1040,7 @@ def reduce_(f, value, dims, require_all_dims_present=False, required_kind: type 
         return f(value._simplify(), dims)
 
 
-def sum_(value: Tensor or list or tuple, dim: DimFilter = non_batch) -> Tensor:
+def sum_(value: Union[Tensor, list, tuple], dim: DimFilter = non_batch) -> Tensor:
     """
     Sums `values` along the specified dimensions.
 
@@ -1092,7 +1092,7 @@ def _sum(value: Tensor, dims: Shape) -> Tensor:
         raise ValueError(type(value))
 
 
-def prod(value: Tensor or list or tuple, dim: DimFilter = non_batch) -> Tensor:
+def prod(value: Union[Tensor, list, tuple], dim: DimFilter = non_batch) -> Tensor:
     """
     Multiplies `values` along the specified dimensions.
 
@@ -1127,7 +1127,7 @@ def _prod(value: Tensor, dims: Shape) -> Tensor:
         raise ValueError(type(value))
 
 
-def mean(value: Tensor or list or tuple, dim: DimFilter = non_batch) -> Tensor:
+def mean(value: Union[Tensor, list, tuple], dim: DimFilter = non_batch) -> Tensor:
     """
     Computes the mean over `values` along the specified dimensions.
 
@@ -1164,7 +1164,7 @@ def _mean(value: Tensor, dims: Shape) -> Tensor:
         raise ValueError(type(value))
 
 
-def std(value: Tensor or list or tuple, dim: DimFilter = non_batch) -> Tensor:
+def std(value: Union[Tensor, list, tuple], dim: DimFilter = non_batch) -> Tensor:
     """
     Computes the standard deviation over `values` along the specified dimensions.
 
@@ -1192,7 +1192,7 @@ def _std(value: Tensor, dims: Shape) -> Tensor:
     return NativeTensor(result, value.shape.without(dims))
 
 
-def any_(boolean_tensor: Tensor or list or tuple, dim: DimFilter = non_batch) -> Tensor:
+def any_(boolean_tensor: Union[Tensor, list, tuple], dim: DimFilter = non_batch) -> Tensor:
     """
     Tests whether any entry of `boolean_tensor` is `True` along the specified dimensions.
 
@@ -1227,7 +1227,7 @@ def _any(value: Tensor, dims: Shape) -> Tensor:
         raise ValueError(type(value))
 
 
-def all_(boolean_tensor: Tensor or list or tuple, dim: DimFilter = non_batch) -> Tensor:
+def all_(boolean_tensor: Union[Tensor, list, tuple], dim: DimFilter = non_batch) -> Tensor:
     """
     Tests whether all entries of `boolean_tensor` are `True` along the specified dimensions.
 
@@ -1262,7 +1262,7 @@ def _all(value: Tensor, dims: Shape) -> Tensor:
         raise ValueError(type(value))
 
 
-def max_(value: Tensor or list or tuple, dim: DimFilter = non_batch) -> Tensor:
+def max_(value: Union[Tensor, list, tuple], dim: DimFilter = non_batch) -> Tensor:
     """
     Determines the maximum value of `values` along the specified dimensions.
 
@@ -1297,7 +1297,7 @@ def _max(value: Tensor, dims: Shape) -> Tensor:
         raise ValueError(type(value))
 
 
-def min_(value: Tensor or list or tuple, dim: DimFilter = non_batch) -> Tensor:
+def min_(value: Union[Tensor, list, tuple], dim: DimFilter = non_batch) -> Tensor:
     """
     Determines the minimum value of `values` along the specified dimensions.
 
@@ -1332,7 +1332,7 @@ def _min(value: Tensor, dims: Shape) -> Tensor:
         raise ValueError(type(value))
 
 
-def finite_min(value, dim: DimFilter = non_batch, default: complex or float = float('NaN')):
+def finite_min(value, dim: DimFilter = non_batch, default: Union[complex, float] = float('NaN')):
     """
     Finds the minimum along `dim` ignoring all non-finite values.
 
@@ -1357,7 +1357,7 @@ def finite_min(value, dim: DimFilter = non_batch, default: complex or float = fl
     return where(is_finite(result_inf), result_inf, default)
 
 
-def finite_max(value, dim: DimFilter = non_batch, default: complex or float = float('NaN')):
+def finite_max(value, dim: DimFilter = non_batch, default: Union[complex, float] = float('NaN')):
     """
     Finds the maximum along `dim` ignoring all non-finite values.
 
@@ -1382,7 +1382,7 @@ def finite_max(value, dim: DimFilter = non_batch, default: complex or float = fl
     return where(is_finite(result_inf), result_inf, default)
 
 
-def finite_sum(value, dim: DimFilter = non_batch, default: complex or float = float('NaN')):
+def finite_sum(value, dim: DimFilter = non_batch, default: Union[complex, float] = float('NaN')):
     """
     Sums all finite values in `value` along `dim`.
 
@@ -1407,7 +1407,7 @@ def finite_sum(value, dim: DimFilter = non_batch, default: complex or float = fl
     return where(any_(finite, dim), summed, default)
 
 
-def finite_mean(value, dim: DimFilter = non_batch, default: complex or float = float('NaN')):
+def finite_mean(value, dim: DimFilter = non_batch, default: Union[complex, float] = float('NaN')):
     """
     Computes the mean value of all finite values in `value` along `dim`.
 
@@ -1435,7 +1435,7 @@ def finite_mean(value, dim: DimFilter = non_batch, default: complex or float = f
 
 
 def quantile(value: Tensor,
-             quantiles: float or tuple or list or Tensor,
+             quantiles: Union[float, tuple, list, Tensor],
              dim: DimFilter = non_batch):
     """
     Compute the q-th quantile of `value` along `dim` for each q in `quantiles`.
@@ -1581,7 +1581,7 @@ def dot(x: Tensor,
     return NativeTensor(result_native, result_shape)
 
 
-def _backend_op1(x, unbound_method) -> Tensor or PhiTreeNode:
+def _backend_op1(x, unbound_method) -> Union[Tensor, PhiTreeNode]:
     if isinstance(x, Tensor):
         def apply_op(native_tensor):
             backend = choose_backend(native_tensor)
@@ -1596,7 +1596,7 @@ def _backend_op1(x, unbound_method) -> Tensor or PhiTreeNode:
         return y
 
 
-def abs_(x) -> Tensor or PhiTreeNode:
+def abs_(x) -> Union[Tensor, PhiTreeNode]:
     """
     Computes *||x||<sub>1</sub>*.
     Complex `x` result in matching precision float values.
@@ -1613,7 +1613,7 @@ def abs_(x) -> Tensor or PhiTreeNode:
     return _backend_op1(x, Backend.abs)
 
 
-def sign(x) -> Tensor or PhiTreeNode:
+def sign(x) -> Union[Tensor, PhiTreeNode]:
     """
     The sign of positive numbers is 1 and -1 for negative numbers.
     The sign of 0 is undefined.
@@ -1627,32 +1627,32 @@ def sign(x) -> Tensor or PhiTreeNode:
     return _backend_op1(x, Backend.sign)
 
 
-def round_(x) -> Tensor or PhiTreeNode:
+def round_(x) -> Union[Tensor, PhiTreeNode]:
     """ Rounds the `Tensor` or `phi.math.magic.PhiTreeNode` `x` to the closest integer. """
     return _backend_op1(x, Backend.round)
 
 
-def ceil(x) -> Tensor or PhiTreeNode:
+def ceil(x) -> Union[Tensor, PhiTreeNode]:
     """ Computes *⌈x⌉* of the `Tensor` or `phi.math.magic.PhiTreeNode` `x`. """
     return _backend_op1(x, Backend.ceil)
 
 
-def floor(x) -> Tensor or PhiTreeNode:
+def floor(x) -> Union[Tensor, PhiTreeNode]:
     """ Computes *⌊x⌋* of the `Tensor` or `phi.math.magic.PhiTreeNode` `x`. """
     return _backend_op1(x, Backend.floor)
 
 
-def sqrt(x) -> Tensor or PhiTreeNode:
+def sqrt(x) -> Union[Tensor, PhiTreeNode]:
     """ Computes *sqrt(x)* of the `Tensor` or `phi.math.magic.PhiTreeNode` `x`. """
     return _backend_op1(x, Backend.sqrt)
 
 
-def exp(x) -> Tensor or PhiTreeNode:
+def exp(x) -> Union[Tensor, PhiTreeNode]:
     """ Computes *exp(x)* of the `Tensor` or `phi.math.magic.PhiTreeNode` `x`. """
     return _backend_op1(x, Backend.exp)
 
 
-def to_float(x) -> Tensor or PhiTreeNode:
+def to_float(x) -> Union[Tensor, PhiTreeNode]:
     """
     Converts the given tensor to floating point format with the currently specified precision.
     
@@ -1672,17 +1672,17 @@ def to_float(x) -> Tensor or PhiTreeNode:
     return _backend_op1(x, Backend.to_float)
 
 
-def to_int32(x) -> Tensor or PhiTreeNode:
+def to_int32(x) -> Union[Tensor, PhiTreeNode]:
     """ Converts the `Tensor` or `phi.math.magic.PhiTreeNode` `x` to 32-bit integer. """
     return _backend_op1(x, Backend.to_int32)
 
 
-def to_int64(x) -> Tensor or PhiTreeNode:
+def to_int64(x) -> Union[Tensor, PhiTreeNode]:
     """ Converts the `Tensor` or `phi.math.magic.PhiTreeNode` `x` to 64-bit integer. """
     return _backend_op1(x, Backend.to_int64)
 
 
-def to_complex(x) -> Tensor or PhiTreeNode:
+def to_complex(x) -> Union[Tensor, PhiTreeNode]:
     """
     Converts the given tensor to complex floating point format with the currently specified precision.
 
@@ -1702,12 +1702,12 @@ def to_complex(x) -> Tensor or PhiTreeNode:
     return _backend_op1(x, Backend.to_complex)
 
 
-def is_finite(x) -> Tensor or PhiTreeNode:
+def is_finite(x) -> Union[Tensor, PhiTreeNode]:
     """ Returns a `Tensor` or `phi.math.magic.PhiTreeNode` matching `x` with values `True` where `x` has a finite value and `False` otherwise. """
     return _backend_op1(x, Backend.isfinite)
 
 
-def real(x) -> Tensor or PhiTreeNode:
+def real(x) -> Union[Tensor, PhiTreeNode]:
     """
     See Also:
         `imag()`, `conjugate()`.
@@ -1721,7 +1721,7 @@ def real(x) -> Tensor or PhiTreeNode:
     return _backend_op1(x, Backend.real)
 
 
-def imag(x) -> Tensor or PhiTreeNode:
+def imag(x) -> Union[Tensor, PhiTreeNode]:
     """
     Returns the imaginary part of `x`.
     If `x` does not store complex numbers, returns a zero tensor with the same shape and dtype as this tensor.
@@ -1738,7 +1738,7 @@ def imag(x) -> Tensor or PhiTreeNode:
     return _backend_op1(x, Backend.imag)
 
 
-def conjugate(x) -> Tensor or PhiTreeNode:
+def conjugate(x) -> Union[Tensor, PhiTreeNode]:
     """
     See Also:
         `imag()`, `real()`.
@@ -1757,36 +1757,36 @@ def degrees(deg):
     return deg * (3.1415 / 180.)
 
 
-def sin(x) -> Tensor or PhiTreeNode:
+def sin(x) -> Union[Tensor, PhiTreeNode]:
     """ Computes *sin(x)* of the `Tensor` or `phi.math.magic.PhiTreeNode` `x`. """
     return _backend_op1(x, Backend.sin)
 
 
-def arcsin(x) -> Tensor or PhiTreeNode:
+def arcsin(x) -> Union[Tensor, PhiTreeNode]:
     """ Computes the inverse of *sin(x)* of the `Tensor` or `phi.math.magic.PhiTreeNode` `x`.
     For real arguments, the result lies in the range [-π/2, π/2].
     """
     return _backend_op1(x, Backend.arcsin)
 
 
-def cos(x) -> Tensor or PhiTreeNode:
+def cos(x) -> Union[Tensor, PhiTreeNode]:
     """ Computes *cos(x)* of the `Tensor` or `phi.math.magic.PhiTreeNode` `x`. """
     return _backend_op1(x, Backend.cos)
 
 
-def arccos(x) -> Tensor or PhiTreeNode:
+def arccos(x) -> Union[Tensor, PhiTreeNode]:
     """ Computes the inverse of *cos(x)* of the `Tensor` or `phi.math.magic.PhiTreeNode` `x`.
     For real arguments, the result lies in the range [0, π].
     """
     return _backend_op1(x, Backend.cos)
 
 
-def tan(x) -> Tensor or PhiTreeNode:
+def tan(x) -> Union[Tensor, PhiTreeNode]:
     """ Computes *tan(x)* of the `Tensor` or `phi.math.magic.PhiTreeNode` `x`. """
     return _backend_op1(x, Backend.tan)
 
 
-def arctan(x, divide_by=None) -> Tensor or PhiTreeNode:
+def arctan(x, divide_by=None) -> Union[Tensor, PhiTreeNode]:
     """
     Computes the inverse of *tan(x)* of the `Tensor` or `phi.math.magic.PhiTreeNode` `x`.
 
@@ -1802,52 +1802,52 @@ def arctan(x, divide_by=None) -> Tensor or PhiTreeNode:
         return custom_op2(x, divide_by, arctan, lambda a, b: choose_backend(a, b).arctan2(a, b), 'arctan')
 
 
-def sinh(x) -> Tensor or PhiTreeNode:
+def sinh(x) -> Union[Tensor, PhiTreeNode]:
     """ Computes *sinh(x)* of the `Tensor` or `phi.math.magic.PhiTreeNode` `x`. """
     return _backend_op1(x, Backend.sinh)
 
 
-def arcsinh(x) -> Tensor or PhiTreeNode:
+def arcsinh(x) -> Union[Tensor, PhiTreeNode]:
     """ Computes the inverse of *sinh(x)* of the `Tensor` or `phi.math.magic.PhiTreeNode` `x`. """
     return _backend_op1(x, Backend.arcsinh)
 
 
-def cosh(x) -> Tensor or PhiTreeNode:
+def cosh(x) -> Union[Tensor, PhiTreeNode]:
     """ Computes *cosh(x)* of the `Tensor` or `phi.math.magic.PhiTreeNode` `x`. """
     return _backend_op1(x, Backend.cosh)
 
 
-def arccosh(x) -> Tensor or PhiTreeNode:
+def arccosh(x) -> Union[Tensor, PhiTreeNode]:
     """ Computes the inverse of *cosh(x)* of the `Tensor` or `phi.math.magic.PhiTreeNode` `x`. """
     return _backend_op1(x, Backend.arccosh)
 
 
-def tanh(x) -> Tensor or PhiTreeNode:
+def tanh(x) -> Union[Tensor, PhiTreeNode]:
     """ Computes *tanh(x)* of the `Tensor` or `phi.math.magic.PhiTreeNode` `x`. """
     return _backend_op1(x, Backend.tanh)
 
 
-def arctanh(x) -> Tensor or PhiTreeNode:
+def arctanh(x) -> Union[Tensor, PhiTreeNode]:
     """ Computes the inverse of *tanh(x)* of the `Tensor` or `phi.math.magic.PhiTreeNode` `x`. """
     return _backend_op1(x, Backend.arctanh)
 
 
-def log(x) -> Tensor or PhiTreeNode:
+def log(x) -> Union[Tensor, PhiTreeNode]:
     """ Computes the natural logarithm of the `Tensor` or `phi.math.magic.PhiTreeNode` `x`. """
     return _backend_op1(x, Backend.log)
 
 
-def log2(x) -> Tensor or PhiTreeNode:
+def log2(x) -> Union[Tensor, PhiTreeNode]:
     """ Computes *log(x)* of the `Tensor` or `phi.math.magic.PhiTreeNode` `x` with base 2. """
     return _backend_op1(x, Backend.log2)
 
 
-def log10(x) -> Tensor or PhiTreeNode:
+def log10(x) -> Union[Tensor, PhiTreeNode]:
     """ Computes *log(x)* of the `Tensor` or `phi.math.magic.PhiTreeNode` `x` with base 10. """
     return _backend_op1(x, Backend.log10)
 
 
-def sigmoid(x) -> Tensor or PhiTreeNode:
+def sigmoid(x) -> Union[Tensor, PhiTreeNode]:
     """ Computes the sigmoid function of the `Tensor` or `phi.math.magic.PhiTreeNode` `x`. """
     return _backend_op1(x, Backend.sigmoid)
 
@@ -1873,7 +1873,7 @@ def cast_same(*values: Tensor) -> Tuple[Tensor]:
         return values
 
 
-def divide_no_nan(x: float or Tensor, y: float or Tensor):
+def divide_no_nan(x: Union[float, Tensor], y: Union[float, Tensor]):
     """ Computes *x/y* with the `Tensor`s `x` and `y` but returns 0 where *y=0*. """
     return custom_op2(x, y,
                       l_operator=divide_no_nan,
@@ -1883,17 +1883,17 @@ def divide_no_nan(x: float or Tensor, y: float or Tensor):
                       op_name='divide_no_nan')
 
 
-def maximum(x: Tensor or float, y: Tensor or float):
+def maximum(x: Union[Tensor, float], y: Union[Tensor, float]):
     """ Computes the element-wise maximum of `x` and `y`. """
     return custom_op2(x, y, maximum, lambda x_, y_: choose_backend(x_, y_).maximum(x_, y_), op_name='maximum')
 
 
-def minimum(x: Tensor or float, y: Tensor or float):
+def minimum(x: Union[Tensor, float], y: Union[Tensor, float]):
     """ Computes the element-wise minimum of `x` and `y`. """
     return custom_op2(x, y, minimum, lambda x_, y_: choose_backend(x_, y_).minimum(x_, y_), op_name='minimum')
 
 
-def clip(x: Tensor, lower_limit: float or Tensor, upper_limit: float or Tensor):
+def clip(x: Tensor, lower_limit: Union[float, Tensor], upper_limit: Union[float, Tensor]):
     """ Limits the values of the `Tensor` `x` to lie between `lower_limit` and `upper_limit` (inclusive). """
     if isinstance(lower_limit, Number) and isinstance(upper_limit, Number):
 
@@ -1977,7 +1977,7 @@ def boolean_mask(x: Tensor, dim: str, mask: Tensor):
     return broadcast_op(uniform_boolean_mask, [x, mask], iter_dims=mask.shape.without(dim))
 
 
-def gather(values: Tensor, indices: Tensor, dims: DimFilter or None = None):
+def gather(values: Tensor, indices: Tensor, dims: Union[DimFilter, None] = None):
     """
     Gathers the entries of `values` at positions described by `indices`.
     All non-channel dimensions of `indices` that are part of `values` but not indexed are treated as batch dimensions.
@@ -2027,9 +2027,9 @@ def gather(values: Tensor, indices: Tensor, dims: DimFilter or None = None):
     return result
 
 
-def scatter(base_grid: Tensor or Shape,
+def scatter(base_grid: Union[Tensor, Shape],
             indices: Tensor,
-            values: Tensor or float,
+            values: Union[Tensor, float],
             mode: str = 'update',
             outside_handling: str = 'discard',
             indices_gradient=False):
@@ -2206,7 +2206,7 @@ def dtype(x) -> DType:
         return choose_backend(x).dtype(x)
 
 
-def expand_tensor(value: float or Tensor, dims: Shape):
+def expand_tensor(value: Union[float, Tensor], dims: Shape):
     if not dims:
         return value
     value = wrap(value)
@@ -2390,7 +2390,7 @@ def stop_gradient(x):
         return wrap(choose_backend(x).stop_gradient(x))
 
 
-def pairwise_distances(positions: Tensor, max_distance: float or Tensor = None, others_dims=instance('others'), format='dense') -> Tensor:
+def pairwise_distances(positions: Tensor, max_distance: Union[float, Tensor] = None, others_dims=instance('others'), format='dense') -> Tensor:
     """
     Computes the distance matrix containing the pairwise position differences between each pair of points.
     Points that are further apart than `max_distance` are assigned a distance value of `0`.

--- a/phi/math/_optimize.py
+++ b/phi/math/_optimize.py
@@ -28,15 +28,15 @@ class Solve(Generic[X, Y]):
     """
 
     def __init__(self,
-                 method: str or None = 'auto',
-                 rel_tol: float or Tensor = None,
-                 abs_tol: float or Tensor = None,
-                 x0: X or Any = None,
+                 method: Union[str, None] = 'auto',
+                 rel_tol: Union[float, Tensor] = None,
+                 abs_tol: Union[float, Tensor] = None,
+                 x0: Union[X, Any] = None,
                  max_iterations: Union[int, Tensor] = 1000,
-                 suppress: tuple or list = (),
+                 suppress: Union[tuple, list] = (),
                  preprocess_y: Callable = None,
                  preprocess_y_args: tuple = (),
-                 gradient_solve: 'Solve[Y, X]' or None = None):
+                 gradient_solve: Union['Solve[Y, X]', None] = None):
         method = method or 'auto'
         assert isinstance(method, str)
         self.method: str = method
@@ -138,9 +138,9 @@ class SolveInfo(Generic[X, Y]):
     def __init__(self,
                  solve: Solve,
                  x: X,
-                 residual: Y or None,
-                 iterations: Tensor or None,
-                 function_evaluations: Tensor or None,
+                 residual: Union[Y, None],
+                 iterations: Union[Tensor, None],
+                 function_evaluations: Union[Tensor, None],
                  converged: Tensor,
                  diverged: Tensor,
                  method: str,
@@ -455,7 +455,7 @@ def solve_nonlinear(f: Callable, y, solve: Solve) -> Tensor:
     return minimize(min_func, min_solve)
 
 
-def solve_linear(f: Callable[[X], Y] or Tensor,
+def solve_linear(f: Union[Callable[[X], Y], Tensor],
                  y: Y,
                  solve: Solve[X, Y],
                  *f_args,

--- a/phi/math/_shape.py
+++ b/phi/math/_shape.py
@@ -59,7 +59,7 @@ class Shape:
             `Shape.name`.
         """
         self.types: Tuple[str] = types  # undocumented, may be private
-        self.item_names: Tuple[str or 'Shape'] = (None,) * len(sizes) if item_names is None else item_names  # undocumented
+        self.item_names: Tuple[Union[str, 'Shape']] = (None,) * len(sizes) if item_names is None else item_names  # undocumented
         if DEBUG_CHECKS:
             assert len(sizes) == len(names) == len(types) == len(item_names), f"sizes={sizes}, names={names}, types={types}, item_names={item_names}"
             assert len(set(names)) == len(names), f"Duplicate dimension names: {names}"
@@ -128,7 +128,7 @@ class Shape:
         else:
             raise ValueError(item)
 
-    def isdisjoint(self, other: 'Shape' or tuple or list or str):
+    def isdisjoint(self, other: Union['Shape', tuple, list, str]):
         """ Shapes are disjoint if all dimension names of one shape do not occur in the other shape. """
         other = parse_dim_order(other)
         return not any(dim in self.names for dim in other)
@@ -136,7 +136,7 @@ class Shape:
     def __iter__(self):
         return iter(self[i] for i in range(self.rank))
 
-    def index(self, dim: str or 'Shape' or None) -> int:
+    def index(self, dim: Union[str, 'Shape', None]) -> int:
         """
         Finds the index of the dimension within this `Shape`.
 
@@ -161,7 +161,7 @@ class Shape:
         else:
             raise ValueError(f"index() requires a single dimension as input but got {dim}")
 
-    def indices(self, dims: tuple or list or 'Shape') -> Tuple[int]:
+    def indices(self, dims: Union[tuple, list, 'Shape']) -> Tuple[int]:
         """
         Finds the indices of the given dimensions within this `Shape`.
 
@@ -181,7 +181,7 @@ class Shape:
         else:
             raise ValueError(f"indices() requires a sequence of dimensions but got {dims}")
 
-    def get_size(self, dim: str or 'Shape' or int, default=None):
+    def get_size(self, dim: Union[str, 'Shape', int], default=None):
         """
         See Also:
             `Shape.get_sizes()`, `Shape.size`
@@ -209,7 +209,7 @@ class Shape:
         else:
             raise ValueError(f"get_size() requires a single dimension but got {dim}. Use indices() to get multiple sizes.")
 
-    def get_sizes(self, dims: tuple or list or 'Shape') -> tuple:
+    def get_sizes(self, dims: Union[tuple, list, 'Shape']) -> tuple:
         """
         See Also:
             `Shape.get_size()`
@@ -223,7 +223,7 @@ class Shape:
         assert isinstance(dims, (tuple, list, Shape)), f"get_sizes() requires a sequence of dimensions but got {dims}"
         return tuple([self.get_size(dim) for dim in dims])
 
-    def get_type(self, dim: str or 'Shape') -> str:
+    def get_type(self, dim: Union[str, 'Shape']) -> str:
         # undocumented, use get_dim_type() instead.
         if isinstance(dim, str):
             return self.types[self.names.index(dim)]
@@ -233,7 +233,7 @@ class Shape:
         else:
             raise ValueError(dim)
 
-    def get_dim_type(self, dim: str or 'Shape') -> Callable:
+    def get_dim_type(self, dim: Union[str, 'Shape']) -> Callable:
         """
         Args:
             dim: Dimension, either as name `str` or single-dimension `Shape`.
@@ -243,7 +243,7 @@ class Shape:
         """
         return {BATCH_DIM: batch, SPATIAL_DIM: spatial, INSTANCE_DIM: instance, CHANNEL_DIM: channel}[self.get_type(dim)]
 
-    def get_types(self, dims: tuple or list or 'Shape') -> tuple:
+    def get_types(self, dims: Union[tuple, list, 'Shape']) -> tuple:
         # undocumented, do not use
         if isinstance(dims, (tuple, list)):
             return tuple(self.get_type(n) for n in dims)
@@ -252,7 +252,7 @@ class Shape:
         else:
             raise ValueError(dims)
 
-    def get_item_names(self, dim: str or 'Shape' or int, fallback_spatial=False) -> tuple or None:
+    def get_item_names(self, dim: Union[str, 'Shape', int], fallback_spatial=False) -> Union[tuple, None]:
         """
         Args:
             fallback_spatial: If `True` and no item names are defined for `dim` and `dim` is a channel dimension, the spatial dimension names are interpreted as item names along `dim` in the order they are listed in this `Shape`.
@@ -277,7 +277,7 @@ class Shape:
         else:
             return None
 
-    def flipped(self, dims: List[str] or Tuple[str]):
+    def flipped(self, dims: Union[List[str], Tuple[str]]):
         item_names = list(self.item_names)
         for dim in dims:
             if dim in self.names:
@@ -534,7 +534,7 @@ class Shape:
         assert self.rank == 1, "int(Shape) is only defined for shapes of rank 1."
         return self.sizes[0]
 
-    def mask(self, names: tuple or list or set or 'Shape'):
+    def mask(self, names: Union[tuple, list, set, 'Shape']):
         """
         Returns a binary sequence corresponding to the names of this Shape.
         A value of 1 means that a dimension of this Shape is contained in `names`.
@@ -590,14 +590,14 @@ class Shape:
     def __bool__(self):
         return self.rank > 0
 
-    def _reorder(self, names: tuple or list or 'Shape') -> 'Shape':
+    def _reorder(self, names: Union[tuple, list, 'Shape']) -> 'Shape':
         assert len(names) == self.rank
         if isinstance(names, Shape):
             names = names.names
         order = [self.index(n) for n in names]
         return self[order]
 
-    def _order_group(self, names: tuple or list or 'Shape') -> list:
+    def _order_group(self, names: Union[tuple, list, 'Shape']) -> list:
         """ Reorders the dimensions of this `Shape` so that `names` are clustered together and occur in the specified order. """
         if isinstance(names, Shape):
             names = names.names
@@ -796,7 +796,7 @@ class Shape:
         indices = [i for i, size in enumerate(self.sizes) if isinstance(size, Tensor) and size.rank > 0]
         return self[indices]
 
-    def with_size(self, size: int or None):
+    def with_size(self, size: Union[int, None]):
         """
         Only for single-dimension shapes.
         Returns a `Shape` representing this dimension but with a different size.
@@ -813,7 +813,7 @@ class Shape:
         assert self.rank == 1, "Shape.with_size() is only defined for shapes of rank 1."
         return self.with_sizes([size])
 
-    def with_sizes(self, sizes: tuple or list or 'Shape' or int, keep_item_names=True):
+    def with_sizes(self, sizes: Union[tuple, list, 'Shape', int], keep_item_names=True):
         """
         Returns a new `Shape` matching the dimension names and types of `self` but with different sizes.
 
@@ -873,7 +873,7 @@ class Shape:
         new_sizes[self.index(dim)] = size
         return self.with_sizes(new_sizes, keep_item_names=keep_item_names)
 
-    def with_dim_size(self, dim: str or 'Shape', size: int or 'math.Tensor' or str or tuple or list, keep_item_names=True):
+    def with_dim_size(self, dim: Union[str, 'Shape'], size: Union[int, 'math.Tensor', str, tuple, list], keep_item_names=True):
         """
         Returns a new `Shape` that has a different size for `dim`.
 
@@ -890,15 +890,15 @@ class Shape:
         new_size, new_item_names = Shape._size_and_item_names_from_obj(size, self.get_size(dim), self.get_item_names(dim), keep_item_names)
         return self.replace(dim, Shape((new_size,), (dim,), (self.get_type(dim),), (new_item_names,)))
 
-    def _with_names(self, names: str or tuple or list):
+    def _with_names(self, names: Union[str, tuple, list]):
         if isinstance(names, str):
             names = parse_dim_names(names, self.rank)
             names = [n if n is not None else o for n, o in zip(names, self.names)]
         return Shape(self.sizes, tuple(names), self.types, self.item_names)
 
     def _replace_names_and_types(self,
-                                 dims: 'Shape' or str or tuple or list,
-                                 new: 'Shape' or str or tuple or list) -> 'Shape':
+                                 dims: Union['Shape', str, tuple, list],
+                                 new: Union['Shape', str, tuple, list]) -> 'Shape':
         """
         Returns a copy of `self` with `dims` replaced by `new`.
         Dimensions that are not present in `self` are ignored.
@@ -929,7 +929,7 @@ class Shape:
                     names[self.index(old_name)] = new_dim
         return Shape(tuple(sizes), tuple(names), tuple(types), tuple(item_names))
 
-    def replace(self, dims: 'Shape' or str or tuple or list, new: 'Shape') -> 'Shape':
+    def replace(self, dims: Union['Shape', str, tuple, list], new: 'Shape') -> 'Shape':
         """
         Returns a copy of `self` with `dims` replaced by `new`.
         Dimensions that are not present in `self` are ignored.
@@ -966,7 +966,7 @@ class Shape:
         to_remove = dims[-(len(dims) - len(new)):]
         return replaced.without(to_remove)
 
-    def _with_types(self, types: 'Shape' or str):
+    def _with_types(self, types: Union['Shape', str]):
         """
         Only for internal use.
         Note: This method does not rename dimensions to comply with type requirements (e.g. ~ for dual dims).
@@ -996,7 +996,7 @@ class Shape:
         return perm
 
     @property
-    def volume(self) -> int or None:
+    def volume(self) -> Union[int, None]:
         """
         Returns the total number of values contained in a tensor of this shape.
         This is the product of all dimension sizes.
@@ -1129,7 +1129,7 @@ class Shape:
     def first_index(self, names=False):
         return next(iter(self.meshgrid(names=names)))
 
-    def are_adjacent(self, dims: str or tuple or list or set or 'Shape'):
+    def are_adjacent(self, dims: Union[str, tuple, list, set, 'Shape']):
         indices = self.indices(dims)
         return (max(indices) - min(indices)) == len(dims) - 1
 
@@ -1196,7 +1196,7 @@ class IncompatibleShapes(Exception):
         self.shapes = shapes
 
 
-def parse_dim_names(obj: str or tuple or list or Shape, count: int) -> tuple:
+def parse_dim_names(obj: Union[str, tuple, list, Shape], count: int) -> tuple:
     if isinstance(obj, str):
         parts = obj.split(',')
         result = []
@@ -1219,7 +1219,7 @@ def parse_dim_names(obj: str or tuple or list or Shape, count: int) -> tuple:
     raise ValueError(obj)
 
 
-def parse_dim_order(order: str or tuple or list or Shape or None, check_rank: int = None) -> tuple or None:
+def parse_dim_order(order: Union[str, tuple, list, Shape, None], check_rank: int = None) -> Union[tuple, None]:
     if order is None:
         if check_rank is not None:
             assert check_rank <= 1, "When calling Tensor.native() or Tensor.numpy(), the dimension order must be specified for Tensors with more than one dimension. The listed default dimension order can vary depending on the chosen backend. Consider using math.reshaped_native(Tensor) instead."
@@ -1333,7 +1333,7 @@ def shape(obj) -> Shape:
             raise ValueError(f'shape() requires Shaped or Shape argument but got {type(obj)}')
 
 
-def spatial(*args, **dims: int or str or tuple or list or Shape) -> Shape:
+def spatial(*args, **dims: Union[int, str, tuple, list, Shape]) -> Shape:
     """
     Returns the spatial dimensions of an existing `Shape` or creates a new `Shape` with only spatial dimensions.
 
@@ -1375,7 +1375,7 @@ def spatial(*args, **dims: int or str or tuple or list or Shape) -> Shape:
         raise AssertionError(f"spatial() must be called either as a selector spatial(Shape) or spatial(Tensor) or as a constructor spatial(*names, **dims). Got *args={args}, **dims={dims}")
 
 
-def channel(*args, **dims: int or str or tuple or list or Shape) -> Shape:
+def channel(*args, **dims: Union[int, str, tuple, list, Shape]) -> Shape:
     """
     Returns the channel dimensions of an existing `Shape` or creates a new `Shape` with only channel dimensions.
 
@@ -1417,7 +1417,7 @@ def channel(*args, **dims: int or str or tuple or list or Shape) -> Shape:
         raise AssertionError(f"channel() must be called either as a selector channel(Shape) or channel(Tensor) or as a constructor channel(*names, **dims). Got *args={args}, **dims={dims}")
 
 
-def batch(*args, **dims: int or str or tuple or list or Shape) -> Shape:
+def batch(*args, **dims: Union[int, str, tuple, list, Shape]) -> Shape:
     """
     Returns the batch dimensions of an existing `Shape` or creates a new `Shape` with only batch dimensions.
 
@@ -1459,7 +1459,7 @@ def batch(*args, **dims: int or str or tuple or list or Shape) -> Shape:
         raise AssertionError(f"batch() must be called either as a selector batch(Shape) or batch(Tensor) or as a constructor batch(*names, **dims). Got *args={args}, **dims={dims}")
 
 
-def instance(*args, **dims: int or str or tuple or list or Shape) -> Shape:
+def instance(*args, **dims: Union[int, str, tuple, list, Shape]) -> Shape:
     """
     Returns the instance dimensions of an existing `Shape` or creates a new `Shape` with only instance dimensions.
 
@@ -1501,7 +1501,7 @@ def instance(*args, **dims: int or str or tuple or list or Shape) -> Shape:
         raise AssertionError(f"instance() must be called either as a selector instance(Shape) or instance(Tensor) or as a constructor instance(*names, **dims). Got *args={args}, **dims={dims}")
 
 
-def dual(*args, **dims: int or str or tuple or list or Shape) -> Shape:
+def dual(*args, **dims: Union[int, str, tuple, list, Shape]) -> Shape:
     """
     Returns the dual dimensions of an existing `Shape` or creates a new `Shape` with only dual dimensions.
 
@@ -1552,7 +1552,7 @@ def dual(*args, **dims: int or str or tuple or list or Shape) -> Shape:
         raise AssertionError(f"dual() must be called either as a selector dual(Shape) or dual(Tensor) or as a constructor dual(*names, **dims). Got *args={args}, **dims={dims}")
 
 
-def merge_shapes(*objs: Shape or Any, order=(batch, dual, instance, spatial, channel), allow_varying_sizes=False):
+def merge_shapes(*objs: Union[Shape, Any], order=(batch, dual, instance, spatial, channel), allow_varying_sizes=False):
     """
     Combines `shapes` into a single `Shape`, grouping dimensions by type.
     If dimensions with equal names are present in multiple shapes, their types and sizes must match.
@@ -1710,7 +1710,7 @@ def _size_equal(s1, s2):
         return math.close(s1, s2)
 
 
-def concat_shapes(*shapes: Shape or Any) -> Shape:
+def concat_shapes(*shapes: Union[Shape, Any]) -> Shape:
     """
     Creates a `Shape` listing the dimensions of all `shapes` in the given order.
 

--- a/phi/math/_sparse.py
+++ b/phi/math/_sparse.py
@@ -1,6 +1,6 @@
 import warnings
 from numbers import Number
-from typing import List, Callable, Tuple
+from typing import List, Callable, Tuple, Union
 
 import numpy as np
 import scipy.sparse
@@ -59,7 +59,7 @@ class SparseCoordinateTensor(Tensor):
     def dtype(self) -> DType:
         return self._values.dtype
 
-    def native(self, order: str or tuple or list or Shape = None):
+    def native(self, order: Union[str, tuple, list, Shape] = None):
         raise RuntimeError("Sparse tensors do not have a native representation. Use math.dense(tensor).native() instead")
 
     @property
@@ -167,7 +167,7 @@ class SparseCoordinateTensor(Tensor):
         pointers = wrap(scipy_csr.indptr, instance('pointers'))
         return CompressedSparseMatrix(indices, pointers, values, u_dims, c_dims, uncompressed_indices=self._indices, uncompressed_indices_perm=perm)
 
-    def __pack_dims__(self, dims: Tuple[str, ...], packed_dim: Shape, pos: int or None, **kwargs) -> 'Tensor':
+    def __pack_dims__(self, dims: Tuple[str, ...], packed_dim: Shape, pos: Union[int, None], **kwargs) -> 'Tensor':
         dims = self._shape.only(dims)
         assert dims in self._dense_shape, f"Can only pack sparse dimensions on SparseCoordinateTensor but got {dims} of which {dims.without(self._dense_shape)} are not sparse"
         assert self._indices.default_backend is NUMPY, "Can only pack NumPy indices as of yet"
@@ -417,10 +417,10 @@ class CompressedSparseMatrix(Tensor):
             self._uncompressed_indices_perm = None
         return SparseCoordinateTensor(self._uncompressed_indices, self._values, self._compressed_dims & self._uncompressed_dims, False, False)
 
-    def native(self, order: str or tuple or list or Shape = None):
+    def native(self, order: Union[str, tuple, list, Shape] = None):
         raise RuntimeError("Sparse tensors do not have a native representation. Use math.dense(tensor).native() instead")
 
-    def __pack_dims__(self, dims: Tuple[str, ...], packed_dim: Shape, pos: int or None, **kwargs) -> 'Tensor':
+    def __pack_dims__(self, dims: Tuple[str, ...], packed_dim: Shape, pos: Union[int, None], **kwargs) -> 'Tensor':
         assert all(d in self._shape for d in dims)
         dims = self._shape.only(dims, reorder=True)
         if dims.only(self._compressed_dims).is_empty:  # pack cols

--- a/phi/math/_trace.py
+++ b/phi/math/_trace.py
@@ -1,5 +1,5 @@
 from collections import namedtuple
-from typing import Callable, Dict, Set, Tuple
+from typing import Callable, Dict, Set, Tuple, Union
 
 import numpy
 import numpy as np
@@ -46,7 +46,7 @@ class ShiftLinTracer(Tensor):
     def __repr__(self):
         return f"Linear tracer {self._shape}"
 
-    def native(self, order: str or tuple or list or Shape = None):
+    def native(self, order: Union[str, tuple, list, Shape] = None):
         """
         Evaluates the value of the linear operation applied to the original source tensor.
 

--- a/phi/math/backend/_backend.py
+++ b/phi/math/backend/_backend.py
@@ -2,7 +2,7 @@ import sys
 import warnings
 from collections import namedtuple
 from contextlib import contextmanager
-from typing import List, Callable, TypeVar, Tuple, Any
+from typing import List, Callable, TypeVar, Tuple, Any, Union
 
 import logging
 import numpy
@@ -83,7 +83,7 @@ class Backend:
     def name(self) -> str:
         return self._name
 
-    def supports(self, feature: str or Callable) -> bool:
+    def supports(self, feature: Union[str, Callable]) -> bool:
         """
         Tests if this backend supports the given feature.
         Features correspond to a method of this backend that must be implemented if the feature is supported.
@@ -163,7 +163,7 @@ class Backend:
     def __repr__(self):
         return self.name
 
-    def list_devices(self, device_type: str or None = None) -> List[ComputeDevice]:
+    def list_devices(self, device_type: Union[str, None] = None) -> List[ComputeDevice]:
         """
         Fetches information about all available compute devices this backend can use.
 
@@ -192,7 +192,7 @@ class Backend:
     def get_default_device(self) -> ComputeDevice:
         return self._default_device
 
-    def set_default_device(self, device: ComputeDevice or str) -> bool:
+    def set_default_device(self, device: Union[ComputeDevice, str]) -> bool:
         """
         Sets the device new tensors will be allocated on.
         This function will do nothing if the target device type is not available.
@@ -359,7 +359,7 @@ class Backend:
     def jit_compile(self, f: Callable) -> Callable:
         return NotImplemented
 
-    def jacobian(self, f: Callable, wrt: tuple or list, get_output: bool, is_f_scalar: bool):
+    def jacobian(self, f: Callable, wrt: Union[tuple, list], get_output: bool, is_f_scalar: bool):
         """
         Args:
             f: Function to differentiate. Returns a tuple containing `(reduced_loss, output)`
@@ -374,7 +374,7 @@ class Backend:
         """
         raise NotImplementedError(self)
 
-    def hessian(self, f: Callable, wrt: tuple or list, get_output: bool, get_gradient: bool) -> tuple:
+    def hessian(self, f: Callable, wrt: Union[tuple, list], get_output: bool, get_gradient: bool) -> tuple:
         """
         First dimension of all inputs/outputs of `f` is assumed to be a batch dimension.
         Element-wise Hessians will be computed along the batch dimension.
@@ -405,17 +405,17 @@ class Backend:
         """
         return NotImplemented
 
-    def jit_compile_grad(self, f: Callable, wrt: tuple or list, get_output: bool, is_f_scalar: bool):
+    def jit_compile_grad(self, f: Callable, wrt: Union[tuple, list], get_output: bool, is_f_scalar: bool):
         raise NotImplementedError()
 
-    def jit_compile_hessian(self, f: Callable, wrt: tuple or list, get_output: bool, get_gradient: bool):
+    def jit_compile_hessian(self, f: Callable, wrt: Union[tuple, list], get_output: bool, get_gradient: bool):
         raise NotImplementedError()
 
     def transpose(self, tensor, axes):
         """ Transposes the dimensions of `tensor` given the new axes order. The tensor will be cast to the default precision in the process. """
         raise NotImplementedError()
 
-    def random_uniform(self, shape, low, high, dtype: DType or None):
+    def random_uniform(self, shape, low, high, dtype: Union[DType, None]):
         """ Float tensor of selected precision containing random values in the range [0, 1) """
         raise NotImplementedError(self)
 
@@ -426,7 +426,7 @@ class Backend:
     def stack(self, values, axis=0):
         raise NotImplementedError(self)
 
-    def stack_leaves(self, trees: tuple or list, axis=0):
+    def stack_leaves(self, trees: Union[tuple, list], axis=0):
         tree0 = trees[0]
         if isinstance(tree0, tuple):
             return tuple([self.stack_leaves([tree[i] for tree in trees], axis=axis) for i in range(len(tree0))])
@@ -462,7 +462,7 @@ class Backend:
     def reshape(self, value, shape):
         raise NotImplementedError(self)
 
-    def flip(self, value, axes: tuple or list):
+    def flip(self, value, axes: Union[tuple, list]):
         slices = tuple(slice(None, None, -1 if i in axes else None) for i in range(self.ndims(value)))
         return value[slices]
 
@@ -513,7 +513,7 @@ class Backend:
     def linspace(self, start, stop, number):
         raise NotImplementedError(self)
 
-    def tensordot(self, a, a_axes: tuple or list, b, b_axes: tuple or list):
+    def tensordot(self, a, a_axes: Union[tuple, list], b, b_axes: Union[tuple, list]):
         """ Multiply-sum-reduce a_axes of a with b_axes of b. """
         raise NotImplementedError(self)
 
@@ -526,7 +526,7 @@ class Backend:
     def cumsum(self, x, axis: int):
         raise NotImplementedError(self)
 
-    def while_loop(self, loop: Callable, values: tuple, max_iter: int or Tuple[int, ...] or List[int]):
+    def while_loop(self, loop: Callable, values: tuple, max_iter: Union[int, Tuple[int, ...], List[int]]):
         """
         If `max_iter is None`, runs
 
@@ -766,7 +766,7 @@ class Backend:
         """
         raise NotImplementedError(self)
 
-    def fft(self, x, axes: tuple or list):
+    def fft(self, x, axes: Union[tuple, list]):
         """
         Computes the n-dimensional FFT along all but the first and last dimensions.
 
@@ -779,7 +779,7 @@ class Backend:
         """
         raise NotImplementedError(self)
 
-    def ifft(self, k, axes: tuple or list):
+    def ifft(self, k, axes: Union[tuple, list]):
         """
         Computes the n-dimensional inverse FFT along all but the first and last dimensions.
 
@@ -908,7 +908,7 @@ class Backend:
         """
         raise NotImplementedError(self)
 
-    def sparse_coo_tensor(self, indices: tuple or list, values, shape: tuple):
+    def sparse_coo_tensor(self, indices: Union[tuple, list], values, shape: tuple):
         """
         Create a sparse matrix in coordinate list (COO) format.
 
@@ -927,7 +927,7 @@ class Backend:
         """
         raise NotImplementedError(self)
 
-    def sparse_coo_tensor_batched(self, indices: tuple or list, values, shape: tuple):
+    def sparse_coo_tensor_batched(self, indices: Union[tuple, list], values, shape: tuple):
         """
         Args:
             indices: shape (batch_size, dims, nnz)
@@ -1414,7 +1414,7 @@ def default_backend() -> Backend:
     return _DEFAULT[-1]
 
 
-def context_backend() -> Backend or None:
+def context_backend() -> Union[Backend, None]:
     """
     Returns the backend set by the inner-most surrounding `with backend:` block.
     If called outside a backend context, returns `None`.

--- a/phi/math/backend/_dtype.py
+++ b/phi/math/backend/_dtype.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 import numpy as np
 import sys
 
@@ -77,7 +79,7 @@ class DType:
         return f"{self.kind.__name__}{self.bits}"
 
     @staticmethod
-    def as_dtype(value: 'DType' or tuple or type or None) -> 'DType' or None:
+    def as_dtype(value: Union['DType', tuple, type, None]) -> Union['DType', None]:
         if isinstance(value, DType):
             return value
         elif value is int:

--- a/phi/math/backend/_linalg.py
+++ b/phi/math/backend/_linalg.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Tuple, Callable
+from typing import Tuple, Callable, Union
 
 import numpy as np
 
@@ -10,7 +10,7 @@ def identity(x):
     return x
 
 
-def stop_on_l2(b: Backend, tolerance_squared, max_iter: np.ndarray, on_diverged: Exception or None = None):
+def stop_on_l2(b: Backend, tolerance_squared, max_iter: np.ndarray, on_diverged: Union[Exception, None] = None):
     max_iter = b.as_tensor(max_iter[-1, :])
     rsq0 = []
     def check_progress(iterations, residual_squared):
@@ -27,7 +27,7 @@ def stop_on_l2(b: Backend, tolerance_squared, max_iter: np.ndarray, on_diverged:
     return check_progress
 
 
-def _max_iter(max_iter: np.ndarray) -> int or list:
+def _max_iter(max_iter: np.ndarray) -> Union[int, list]:
     trj_size, batch_size = max_iter.shape
     if trj_size == 1:
         return int(np.max(max_iter))
@@ -36,7 +36,7 @@ def _max_iter(max_iter: np.ndarray) -> int or list:
         return max_iter[:, 0].tolist()
 
 
-def cg(b: Backend, lin, y, x0, check_progress: Callable, max_iter, pre: Callable = identity) -> SolveResult or List[SolveResult]:
+def cg(b: Backend, lin, y, x0, check_progress: Callable, max_iter, pre: Callable = identity) -> Union[SolveResult, List[SolveResult]]:
     """
     Based on "An Introduction to the Conjugate Gradient Method Without the Agonizing Pain" by Jonathan Richard Shewchuk
     symbols: dx=d, dy=q, step_size=alpha, residual_squared=delta, residual=r, y=b, pre=M
@@ -72,7 +72,7 @@ def cg(b: Backend, lin, y, x0, check_progress: Callable, max_iter, pre: Callable
     return SolveResult(f"Φ-Flow CG ({b.name})", x, residual, iterations, function_evaluations, converged, diverged, [""] * batch_size)
 
 
-def cg_adaptive(b, lin, y, x0, check_progress: Callable, max_iter) -> SolveResult or List[SolveResult]:
+def cg_adaptive(b, lin, y, x0, check_progress: Callable, max_iter) -> Union[SolveResult, List[SolveResult]]:
     """
     Based on the variant described in "Methods of Conjugate Gradients for Solving Linear Systems" by Magnus R. Hestenes and Eduard Stiefel https://nvlpubs.nist.gov/nistpubs/jres/049/jresv49n6p409_A1b.pdf
     """
@@ -106,7 +106,7 @@ def cg_adaptive(b, lin, y, x0, check_progress: Callable, max_iter) -> SolveResul
     return SolveResult(f"Φ-Flow CG-adaptive ({b.name})", x, residual, iterations, function_evaluations, converged, diverged, [""] * batch_size)
 
 
-def bicg(b: Backend, lin, y, x0, check_progress: Callable, max_iter, poly_order: int) -> SolveResult or List[SolveResult]:
+def bicg(b: Backend, lin, y, x0, check_progress: Callable, max_iter, poly_order: int) -> Union[SolveResult, List[SolveResult]]:
     """ Adapted from [BiCGstab for linear equations involving unsymmetric matrices with complex spectrum](https://dspace.library.uu.nl/bitstream/handle/1874/16827/sleijpen_93_bicgstab.pdf) """
     # Based on "BiCGstab(L) for linear equations involving unsymmetric matrices with complex spectrum" by Gerard L.G. Sleijpen
     y = b.to_float(y)

--- a/phi/math/backend/_numpy_backend.py
+++ b/phi/math/backend/_numpy_backend.py
@@ -1,7 +1,7 @@
 import numbers
 import os
 import sys
-from typing import List, Any, Callable
+from typing import List, Any, Callable, Union
 
 import numpy as np
 import numpy.random
@@ -139,7 +139,7 @@ class NumPyBackend(Backend):
             result = x / y
         return np.where(y == 0, 0, result)
 
-    def random_uniform(self, shape, low, high, dtype: DType or None):
+    def random_uniform(self, shape, low, high, dtype: Union[DType, None]):
         dtype = dtype or self.float_type
         if dtype.kind == float:
             return np.random.uniform(low, high, shape).astype(to_numpy_dtype(dtype))
@@ -199,7 +199,7 @@ class NumPyBackend(Backend):
     def mean(self, value, axis=None, keepdims=False):
         return np.mean(value, axis, keepdims=keepdims)
 
-    def tensordot(self, a, a_axes: tuple or list, b, b_axes: tuple or list):
+    def tensordot(self, a, a_axes: Union[tuple, list], b, b_axes: Union[tuple, list]):
         return np.tensordot(a, b, (a_axes, b_axes))
 
     def mul(self, a, b):
@@ -309,7 +309,7 @@ class NumPyBackend(Backend):
     def quantile(self, x, quantiles):
         return np.quantile(x, quantiles, axis=-1)
 
-    def fft(self, x, axes: tuple or list):
+    def fft(self, x, axes: Union[tuple, list]):
         x = self.to_complex(x)
         if not axes:
             return x
@@ -320,7 +320,7 @@ class NumPyBackend(Backend):
         else:
             return np.fft.fftn(x, axes=axes).astype(x.dtype)
 
-    def ifft(self, k, axes: tuple or list):
+    def ifft(self, k, axes: Union[tuple, list]):
         if not axes:
             return k
         if len(axes) == 1:
@@ -371,7 +371,7 @@ class NumPyBackend(Backend):
     def stop_gradient(self, value):
         return value
 
-    # def jacobian(self, f, wrt: tuple or list, get_output: bool):
+    # def jacobian(self, f, wrt: Union[tuple, list], get_output: bool):
     #     warnings.warn("NumPy does not support analytic gradients and will use differences instead. This may be slow!", RuntimeWarning)
     #     eps = {64: 1e-9, 32: 1e-4, 16: 1e-1}[self.precision]
     #

--- a/phi/math/backend/_profile.py
+++ b/phi/math/backend/_profile.py
@@ -2,7 +2,7 @@ import inspect
 import json
 from contextlib import contextmanager
 from time import perf_counter
-from typing import Optional, Callable
+from typing import Optional, Callable, Union
 
 from ._backend import Backend, BACKENDS, _DEFAULT
 
@@ -58,11 +58,11 @@ class ExtCall:
     """ Function invocation that is not a Backend method but internally calls Backend methods. """
 
     def __init__(self,
-                 parent: 'ExtCall' or None,
+                 parent: Union['ExtCall', None],
                  name: str,
                  level: int,
                  function: str,
-                 code_context: list or None,
+                 code_context: Union[list, None],
                  file_name: str,
                  line_number: int):
         """
@@ -232,7 +232,7 @@ class Profile:
     Profiles can be printed or saved to disc.
     """
 
-    def __init__(self, trace: bool, backends: tuple or list, subtract_trace_time: bool):
+    def __init__(self, trace: bool, backends: Union[tuple, list], subtract_trace_time: bool):
         self._start = perf_counter()
         self._stop = None
         self._root = ExtCall(None, "", 0, "", "", "", -1)
@@ -469,7 +469,7 @@ _PROFILE = []
 
 
 @contextmanager
-def profile(backends=None, trace=True, subtract_trace_time=True, save: str or None = None) -> Profile:
+def profile(backends=None, trace=True, subtract_trace_time=True, save: Union[str, None] = None) -> Profile:
     """
     To be used in `with` statements, `with math.backend.profile() as prof: ...`.
     Creates a `Profile` for the code executed within the context by tracking calls to the `backends` and optionally tracing the call.
@@ -495,8 +495,8 @@ def profile(backends=None, trace=True, subtract_trace_time=True, save: str or No
 
 
 def profile_function(fun: Callable,
-                     args: tuple or list = (),
-                     kwargs: dict or None = None,
+                     args: Union[tuple, list] = (),
+                     kwargs: Union[dict, None] = None,
                      backends=None,
                      trace=True,
                      subtract_trace_time=True,
@@ -538,7 +538,7 @@ def profile_function(fun: Callable,
     return prof
 
 
-def _start_profiling(prof: Profile, backends: tuple or list):
+def _start_profiling(prof: Profile, backends: Union[tuple, list]):
     _PROFILE.append(prof)
     original_default = _DEFAULT[-1]
     original_backends = tuple(BACKENDS)

--- a/phi/math/extrapolation.py
+++ b/phi/math/extrapolation.py
@@ -191,7 +191,7 @@ class ConstantExtrapolation(Extrapolation):
     Extrapolate with a constant value.
     """
 
-    def __init__(self, value: Tensor or float):
+    def __init__(self, value: Union[Tensor, float]):
         Extrapolation.__init__(self, 5)
         self.value = wrap(value)
         """ Extrapolation value """
@@ -1057,7 +1057,7 @@ def as_extrapolation(obj) -> Extrapolation:
     return ConstantExtrapolation(obj)
 
 
-def combine_sides(**extrapolations: Extrapolation or tuple) -> Extrapolation:
+def combine_sides(**extrapolations: Union[Extrapolation, tuple]) -> Extrapolation:
     """
     Specify extrapolations for each side / face of a box.
 
@@ -1342,7 +1342,7 @@ class _NormalTangentialExtrapolation(Extrapolation):
         return combine_by_direction(normal=-self.normal, tangential=-self.tangential)
 
 
-def combine_by_direction(normal: Extrapolation or float or Tensor, tangential: Extrapolation or float or Tensor) -> Extrapolation:
+def combine_by_direction(normal: Union[Extrapolation, float, Tensor], tangential: Union[Extrapolation, float, Tensor]) -> Extrapolation:
     """
     Use a different extrapolation for the normal component of vector-valued tensors.
 
@@ -1390,7 +1390,7 @@ def from_dict(dictionary: dict) -> Extrapolation:
         raise ValueError(dictionary)
 
 
-def order_by_shape(shape: Shape, sequence, default=None) -> tuple or list:
+def order_by_shape(shape: Shape, sequence, default=None) -> Union[tuple, list]:
     """
     If sequence is a dict with dimension names as keys, orders its values according to this shape.
 

--- a/phi/math/magic.py
+++ b/phi/math/magic.py
@@ -16,7 +16,7 @@ This is analogous to interfaces defined in the built-in `collections` package, s
 To check whether `len(obj)` can be performed, you check `isinstance(obj, Sized)`.
 """
 import warnings
-from typing import Tuple, Callable
+from typing import Tuple, Callable, Union
 
 import dataclasses
 
@@ -242,7 +242,7 @@ class Shapable(metaclass=_ShapableType):
         """
         raise NotImplementedError
 
-    def __pack_dims__(self, dims: Tuple[str, ...], packed_dim: Shape, pos: int or None, **kwargs) -> 'Shapable':
+    def __pack_dims__(self, dims: Tuple[str, ...], packed_dim: Shape, pos: Union[int, None], **kwargs) -> 'Shapable':
         """
         Compresses multiple dimensions into a single dimension by concatenating the elements.
         Elements along the new dimensions are laid out according to the order of `dims`.
@@ -522,7 +522,7 @@ class BoundDim:
     def __getattr__(self, item):
         return _BoundDims(self.obj, (self.name, item))
 
-    def unstack(self, size: int or None = None) -> tuple:
+    def unstack(self, size: Union[int, None] = None) -> tuple:
         """
         Lists the slices along this dimension as a `tuple`.
 

--- a/phi/physics/_boundaries.py
+++ b/phi/physics/_boundaries.py
@@ -1,5 +1,6 @@
 import warnings
 from numbers import Number
+from typing import Union
 
 from phi import math, field
 from phi.field import CenteredGrid, StaggeredGrid, PointCloud, Field, mask
@@ -18,7 +19,7 @@ Please create grids directly, replacing the domain with a dict, e.g.
     grid = CenteredGrid(0, **domain)""", FutureWarning, stacklevel=2)
 
 
-def _create_boundary_conditions(obj: dict or tuple or list, spatial_dims: tuple) -> dict:
+def _create_boundary_conditions(obj: Union[dict, tuple, list], spatial_dims: tuple) -> dict:
     """
     Construct mixed boundary conditions from from a sequence of boundary conditions.
 
@@ -70,7 +71,7 @@ PERIODIC = {
 
 class Domain:
 
-    def __init__(self, resolution: math.Shape or tuple or list = math.EMPTY_SHAPE, boundaries: dict or tuple or list = OPEN, bounds: Box = None, **resolution_):
+    def __init__(self, resolution: Union[math.Shape, tuple, list] = math.EMPTY_SHAPE, boundaries: Union[dict, tuple, list] = OPEN, bounds: Box = None, **resolution_):
         """
         The Domain specifies the grid resolution, physical size and boundary conditions of a simulation.
 
@@ -132,9 +133,9 @@ class Domain:
         return self.cells.center
 
     def grid(self,
-             value: Field or Tensor or Number or Geometry or callable = 0.,
+             value: Union[Field, Tensor, Number, Geometry, callable] = 0.,
              type: type = CenteredGrid,
-             extrapolation: math.Extrapolation = 'scalar') -> CenteredGrid or StaggeredGrid:
+             extrapolation: math.Extrapolation = 'scalar') -> Union[CenteredGrid, StaggeredGrid]:
         """
         Creates a grid matching the resolution and bounds of the domain.
         The grid is created from the given `value` which must be one of the following:
@@ -157,8 +158,8 @@ class Domain:
         return type(value, resolution=self.resolution, bounds=self.bounds, extrapolation=extrapolation)
 
     def scalar_grid(self,
-                    value: Field or Tensor or Number or Geometry or callable = 0.,
-                    extrapolation: str or math.Extrapolation = 'scalar') -> CenteredGrid:
+                    value: Union[Field, Tensor, Number, Geometry, callable] = 0.,
+                    extrapolation: Union[str, math.Extrapolation] = 'scalar') -> CenteredGrid:
         """
         Creates a scalar grid matching the resolution and bounds of the domain.
         The grid is created from the given `value` which must be one of the following:
@@ -197,9 +198,9 @@ class Domain:
         return result
 
     def vector_grid(self,
-                    value: Field or Tensor or Number or Geometry or callable = 0.,
+                    value: Union[Field, Tensor, Number, Geometry, callable] = 0.,
                     type: type = CenteredGrid,
-                    extrapolation: math.Extrapolation or str = 'vector') -> CenteredGrid or StaggeredGrid:
+                    extrapolation: Union[math.Extrapolation, str] = 'vector') -> Union[CenteredGrid, StaggeredGrid]:
         """
         Creates a vector grid matching the resolution and bounds of the domain.
         The grid is created from the given `value` which must be one of the following:
@@ -229,8 +230,8 @@ class Domain:
         return result
 
     def staggered_grid(self,
-                       value: Field or Tensor or Number or Geometry or callable = 0.,
-                       extrapolation: math.Extrapolation or str = 'vector') -> StaggeredGrid:
+                       value: Union[Field, Tensor, Number, Geometry, callable] = 0.,
+                       extrapolation: Union[math.Extrapolation, str] = 'vector') -> StaggeredGrid:
         """
         Creates a staggered grid matching the resolution and bounds of the domain.
         This is equal to calling `vector_grid()` with `type=StaggeredGrid`.
@@ -255,8 +256,8 @@ class Domain:
         return self.vector_grid(value, type=StaggeredGrid, extrapolation=extrapolation)
 
     def vector_potential(self,
-                         value: Field or Tensor or Number or Geometry or callable = 0.,
-                         extrapolation: str or math.Extrapolation = 'scalar',
+                         value: Union[Field, Tensor, Number, Geometry, callable] = 0.,
+                         extrapolation: Union[str, math.Extrapolation] = 'scalar',
                          curl_type=CenteredGrid):
         if self.rank == 2 and curl_type == StaggeredGrid:
             pot_bounds = Box(self.bounds.lower - 0.5 * self.dx, self.bounds.upper + 0.5 * self.dx)
@@ -264,7 +265,7 @@ class Domain:
             return alt_domain.scalar_grid(value, extrapolation=extrapolation)
         raise NotImplementedError()
 
-    def accessible_mask(self, not_accessible: tuple or list, type: type = CenteredGrid, extrapolation='accessible') -> CenteredGrid or StaggeredGrid:
+    def accessible_mask(self, not_accessible: Union[tuple, list], type: type = CenteredGrid, extrapolation='accessible') -> Union[CenteredGrid, StaggeredGrid]:
         """
         Unifies domain and Obstacle or Geometry objects into a binary StaggeredGrid mask which can be used
         to enforce boundary conditions.
@@ -287,11 +288,11 @@ class Domain:
             raise ValueError('Unknown grid type: %s' % type)
 
     def points(self,
-               points: Tensor or Number or tuple or list,
-               values: Tensor or Number = None,
-               radius: Tensor or float or int or None = None,
+               points: Union[Tensor, Number, tuple, list],
+               values: Union[Tensor, Number] = None,
+               radius: Union[Tensor, float, int, None] = None,
                extrapolation: math.Extrapolation = math.extrapolation.ZERO,
-               color: str or Tensor or tuple or list or None = None) -> PointCloud:
+               color: Union[str, Tensor, tuple, list, None] = None) -> PointCloud:
         """
         Create a `phi.field.PointCloud` from the given `points`.
         The created field has no channel dimensions and all points carry the value `1`.
@@ -323,7 +324,7 @@ class Domain:
         return PointCloud(elements, values, extrapolation, add_overlapping=False, bounds=self.bounds, color=color)
 
     def distribute_points(self,
-                          geometries: tuple or list,
+                          geometries: Union[tuple, list],
                           points_per_cell: int = 8,
                           color: str = None,
                           center: bool = False) -> PointCloud:

--- a/phi/physics/advect.py
+++ b/phi/physics/advect.py
@@ -7,6 +7,8 @@ Examples:
 * mac_cormack (grid)
 * runge_kutta_4 (particle)
 """
+from typing import Union
+
 from phi.math import Solve, channel
 
 from phi import math
@@ -48,7 +50,7 @@ def finite_rk4(elements: Geometry, velocity: Grid, dt: float, v0: math.Tensor = 
 
 def advect(field: SampledField,
            velocity: Field,
-           dt: float or math.Tensor,
+           dt: Union[float, math.Tensor],
            integrator=euler) -> FieldType:
     """
     Advect `field` along the `velocity` vectors using the specified integrator.

--- a/phi/physics/diffuse.py
+++ b/phi/physics/diffuse.py
@@ -1,6 +1,8 @@
 """
 Functions to simulate diffusion processes on `phi.field.Field` objects.
 """
+from typing import Union
+
 from phi import math
 from phi.field import Grid, Field, laplace, solve_linear, jit_compile_linear
 from phi.field._field import FieldType
@@ -9,8 +11,8 @@ from phi.math import copy_with, shape, Solve
 
 
 def explicit(field: FieldType,
-             diffusivity: float or math.Tensor or Field,
-             dt: float or math.Tensor,
+             diffusivity: Union[float, math.Tensor, Field],
+             dt: Union[float, math.Tensor],
              substeps: int = 1) -> FieldType:
     """
     Simulate a finite-time diffusion process of the form dF/dt = α · ΔF on a given `Field` FieldType with diffusion coefficient α.
@@ -37,8 +39,8 @@ def explicit(field: FieldType,
 
 
 def implicit(field: FieldType,
-             diffusivity: float or math.Tensor or Field,
-             dt: float or math.Tensor,
+             diffusivity: Union[float, math.Tensor, Field],
+             dt: Union[float, math.Tensor],
              order: int = 1,
              solve=Solve('CG')) -> FieldType:
     """
@@ -64,7 +66,7 @@ def implicit(field: FieldType,
 
 
 def finite_difference(grid: Grid,
-                      diffusivity: float or math.Tensor or Field,
+                      diffusivity: Union[float, math.Tensor, Field],
                       order: int,
                       implicit: math.Solve) -> FieldType:
 
@@ -90,8 +92,8 @@ def finite_difference(grid: Grid,
 
 
 def fourier(field: GridType,
-            diffusivity: float or math.Tensor,
-            dt: float or math.Tensor) -> FieldType:
+            diffusivity: Union[float, math.Tensor],
+            dt: Union[float, math.Tensor]) -> FieldType:
     """
     Exact diffusion of a periodic field in frequency space.
 

--- a/phi/physics/fluid.py
+++ b/phi/physics/fluid.py
@@ -4,7 +4,7 @@ Functions for simulating incompressible fluids, both grid-based and particle-bas
 The main function for incompressible fluids (Eulerian as well as FLIP / PIC) is `make_incompressible()` which removes the divergence of a velocity field.
 """
 import warnings
-from typing import Tuple, Callable
+from typing import Tuple, Callable, Union
 
 from phi import math, field
 from phi.math import wrap, channel, Solve
@@ -63,7 +63,7 @@ def _get_obstacles_for(obstacles, space: Field):
 
 
 def make_incompressible(velocity: GridType,
-                        obstacles: Obstacle or Geometry or tuple or list = (),
+                        obstacles: Union[Obstacle, Geometry, tuple, list] = (),
                         solve: Solve = Solve(),
                         active: CenteredGrid = None,
                         order: int = 2) -> Tuple[GridType, CenteredGrid]:
@@ -157,7 +157,7 @@ def _balance_divergence(div, active):
     return div - active * (field.mean(div) / field.mean(active))
 
 
-def apply_boundary_conditions(velocity: Grid or PointCloud, obstacles: Obstacle or Geometry or tuple or list):
+def apply_boundary_conditions(velocity: Union[Grid, PointCloud], obstacles: Union[Obstacle, Geometry, tuple, list]):
     """
     Enforces velocities boundary conditions on a velocity grid.
     Cells inside obstacles will get their velocity from the obstacle movement.
@@ -185,7 +185,7 @@ def apply_boundary_conditions(velocity: Grid or PointCloud, obstacles: Obstacle 
     return velocity
 
 
-def boundary_push(particles: PointCloud, obstacles: tuple or list, offset: float = 0.5) -> PointCloud:
+def boundary_push(particles: PointCloud, obstacles: Union[tuple, list], offset: float = 0.5) -> PointCloud:
     """
     Enforces boundary conditions by correcting possible errors of the advection step and shifting particles out of
     obstacles or back into the domain.

--- a/phi/tf/_tf_backend.py
+++ b/phi/tf/_tf_backend.py
@@ -1,7 +1,7 @@
 import numbers
 from contextlib import contextmanager
 from functools import wraps, partial
-from typing import List, Callable, Tuple
+from typing import List, Callable, Tuple, Union
 
 import keras
 import numpy as np
@@ -131,7 +131,7 @@ class TFBackend(Backend):
             x, y = self.auto_cast(x, y)
             return tf.math.divide_no_nan(x, y)
 
-    def random_uniform(self, shape, low, high, dtype: DType or None):
+    def random_uniform(self, shape, low, high, dtype: Union[DType, None]):
         dtype = dtype or self.float_type
         tdt = to_numpy_dtype(dtype)
         with tf.device(self._default_device.ref):
@@ -263,7 +263,7 @@ class TFBackend(Backend):
         with tf.device(self._default_device.ref):
             return self.to_float(tf.linspace(start, stop, number))
 
-    def tensordot(self, a, a_axes: tuple or list, b, b_axes: tuple or list):
+    def tensordot(self, a, a_axes: Union[tuple, list], b, b_axes: Union[tuple, list]):
         with self._device_for(a, b):
             a, b = self.auto_cast(a, b, bool_to_int=True)
             return tf.tensordot(a, b, (a_axes, b_axes))
@@ -286,7 +286,7 @@ class TFBackend(Backend):
         with tf.device(x.device):
             return tf.cumsum(x, axis=axis, exclusive=False)
 
-    def while_loop(self, loop: Callable, values: tuple, max_iter: int or Tuple[int, ...] or List[int]):
+    def while_loop(self, loop: Callable, values: tuple, max_iter: Union[int, Tuple[int, ...], List[int]]):
         with self._device_for(*values):
             if isinstance(max_iter, (tuple, list)):  # stack traced trajectory, unroll until max_iter
                 values = self.stop_gradient_tree(values)
@@ -479,7 +479,7 @@ class TFBackend(Backend):
                 result.append(scatter(b_grid, b_indices, b_values))
             return self.stack(result, axis=0)
 
-    def fft(self, x, axes: tuple or list):
+    def fft(self, x, axes: Union[tuple, list]):
         if not axes:
             return x
         x = self.to_complex(x)
@@ -497,7 +497,7 @@ class TFBackend(Backend):
                     x = self.fft(x, [axis])
                 return x
 
-    def ifft(self, k, axes: tuple or list):
+    def ifft(self, k, axes: Union[tuple, list]):
         if not axes:
             return k
         k = self.to_complex(k)
@@ -700,7 +700,7 @@ class TFBackend(Backend):
             a, b = self.auto_cast(a, b)
             return a // b
 
-    def jacobian(self, f, wrt: tuple or list, get_output: bool, is_f_scalar: bool):
+    def jacobian(self, f, wrt: Union[tuple, list], get_output: bool, is_f_scalar: bool):
         @wraps(f)
         def eval_grad(*args):
             args = [self.as_tensor(arg, True) if i in wrt else arg for i, arg in enumerate(args)]

--- a/phi/tf/nets.py
+++ b/phi/tf/nets.py
@@ -4,7 +4,7 @@ Equivalent functions also exist for the other frameworks.
 
 For API documentation, see https://tum-pbs.github.io/PhiFlow/Network_API .
 """
-from typing import Callable, Tuple, List
+from typing import Callable, Tuple, List, Union
 import pickle
 from typing import Callable
 from typing import Tuple, List
@@ -72,7 +72,7 @@ def get_parameters(model: keras.Model, wrap=True) -> dict:
     return result
 
 
-def save_state(obj: keras.models.Model or keras.optimizers.Optimizer, path: str):
+def save_state(obj: Union[keras.models.Model, keras.optimizers.Optimizer], path: str):
     """
     Write the state of a module or optimizer to a file.
 
@@ -97,7 +97,7 @@ def save_state(obj: keras.models.Model or keras.optimizers.Optimizer, path: str)
         raise ValueError("obj must be a Keras model or optimizer")
 
 
-def load_state(obj: keras.models.Model or keras.optimizers.Optimizer, path: str):
+def load_state(obj: Union[keras.models.Model, keras.optimizers.Optimizer], path: str):
     """
     Read the state of a module or optimizer from a file.
 
@@ -180,7 +180,7 @@ def rmsprop(net: keras.Model, learning_rate: float = 1e-3, alpha=0.99, eps=1e-08
 
 def dense_net(in_channels: int,
               out_channels: int,
-              layers: Tuple[int, ...] or List[int],
+              layers: Union[Tuple[int, ...], List[int]],
               batch_norm=False,
               activation='ReLU',
               softmax=False) -> keras.Model:
@@ -211,10 +211,10 @@ def dense_net(in_channels: int,
 def u_net(in_channels: int,
           out_channels: int,
           levels: int = 4,
-          filters: int or tuple or list = 16,
+          filters: Union[int, tuple, list] = 16,
           batch_norm: bool = True,
-          activation: str or Callable = 'ReLU',
-          in_spatial: tuple or int = 2,
+          activation: Union[str, Callable] = 'ReLU',
+          in_spatial: Union[tuple, int] = 2,
           periodic=False,
           use_res_blocks: bool = False, **kwargs) -> keras.Model:
     """
@@ -295,11 +295,11 @@ def double_conv(x, d: int, out_channels: int, mid_channels: int, batch_norm: boo
 
 def conv_net(in_channels: int,
              out_channels: int,
-             layers: Tuple[int, ...] or List[int],
+             layers: Union[Tuple[int, ...], List[int]],
              batch_norm: bool = False,
-             activation: str or Callable = 'ReLU',
+             activation: Union[str, Callable] = 'ReLU',
              periodic=False,
-             in_spatial: int or tuple = 2, **kwargs) -> keras.Model:
+             in_spatial: Union[int, tuple] = 2, **kwargs) -> keras.Model:
     """
     Built in Conv-Nets are also provided. Contrary to the classical convolutional neural networks, the feature map spatial size remains the same throughout the layers. Each layer of the network is essentially a convolutional block comprising of two conv layers. A filter size of 3 is used in the convolutional layers.
     Arguments:
@@ -338,8 +338,8 @@ def resnet_block(in_channels: int,
                  out_channels: int,
                  periodic: bool,
                  batch_norm: bool = False,
-                 activation: str or Callable = 'ReLU',
-                 in_spatial: int or tuple = 2):
+                 activation: Union[str, Callable] = 'ReLU',
+                 in_spatial: Union[int, tuple] = 2):
     activation = ACTIVATIONS[activation] if isinstance(activation, str) else activation
     if isinstance(in_spatial, int):
         d = in_spatial
@@ -365,11 +365,11 @@ def resnet_block(in_channels: int,
 
 def res_net(in_channels: int,
             out_channels: int,
-            layers: Tuple[int, ...] or List[int],
+            layers: Union[Tuple[int, ...], List[int]],
             batch_norm: bool = False,
-            activation: str or Callable = 'ReLU',
+            activation: Union[str, Callable] = 'ReLU',
             periodic=False,
-            in_spatial: int or tuple = 2, **kwargs):
+            in_spatial: Union[int, tuple] = 2, **kwargs):
     """
     Built in Res-Nets are provided in the ΦFlow framework. Similar to the conv-net, the feature map spatial size remains the same throughout the layers.
     These networks use residual blocks composed of two conv layers with a skip connection added from the input to the output feature map.
@@ -406,7 +406,7 @@ def res_net(in_channels: int,
 
 
 def conv_classifier(in_features: int,
-                    in_spatial: tuple or list,
+                    in_spatial: Union[tuple, list],
                     num_classes: int,
                     blocks=(64, 128, 256, 256, 512, 512),
                     dense_layers=(4096, 4096, 100),
@@ -480,7 +480,7 @@ def get_mask(inputs, reverse_mask, data_format='NHWC'):
 def Dense_resnet_block(in_channels: int,
                        mid_channels: int,
                        batch_norm: bool = False,
-                       activation: str or Callable = 'ReLU'):
+                       activation: Union[str, Callable] = 'ReLU'):
     inputs = keras.Input(shape=(in_channels,))
     x_1 = inputs
     activation = ACTIVATIONS[activation] if isinstance(activation, str) else activation
@@ -580,8 +580,8 @@ def invertible_net(in_channels: int,
                    num_blocks: int,
                    batch_norm: bool = False,
                    net: str = 'u_net',
-                   activation: str or type = 'ReLU',
-                   in_spatial: tuple or int = 2, **kwargs):
+                   activation: Union[str, type] = 'ReLU',
+                   in_spatial: Union[tuple, int] = 2, **kwargs):
     """
     ΦFlow also provides invertible neural networks that are capable of inverting the output tensor back to the input tensor initially passed.\ These networks have far reaching applications in predicting input parameters of a problem given its observations.\ Invertible nets are composed of multiple concatenated coupling blocks wherein each such block consists of arbitrary neural networks.
 
@@ -780,8 +780,8 @@ class FNO(keras.Model):
 def fno(in_channels: int,
         out_channels: int,
         mid_channels: int,
-        modes: Tuple[int, ...] or List[int],
-        activation: str or type = 'ReLU',
+        modes: Union[Tuple[int, ...], List[int]],
+        activation: Union[str, type] = 'ReLU',
         batch_norm: bool = False,
         in_spatial: int = 2):
     """

--- a/phi/torch/nets.py
+++ b/phi/torch/nets.py
@@ -4,7 +4,7 @@ Equivalent functions also exist for the other frameworks.
 
 For API documentation, see https://tum-pbs.github.io/PhiFlow/Network_API .
 """
-from typing import Callable, List, Tuple
+from typing import Callable, List, Tuple, Union
 
 import numpy
 import numpy as np
@@ -56,7 +56,7 @@ def get_parameters(net: nn.Module, wrap=True) -> dict:
     return result
 
 
-def save_state(obj: nn.Module or optim.Optimizer, path: str):
+def save_state(obj: Union[nn.Module, optim.Optimizer], path: str):
     """
     Write the state of a module or optimizer to a file.
 
@@ -72,7 +72,7 @@ def save_state(obj: nn.Module or optim.Optimizer, path: str):
     torch.save(obj.state_dict(), path)
 
 
-def load_state(obj: nn.Module or optim.Optimizer, path: str):
+def load_state(obj: Union[nn.Module, optim.Optimizer], path: str):
     """
     Read the state of a module or optimizer from a file.
 
@@ -161,9 +161,9 @@ ACTIVATIONS = {'ReLU': nn.ReLU, 'Sigmoid': nn.Sigmoid, 'tanh': nn.Tanh, 'SiLU': 
 
 def dense_net(in_channels: int,
               out_channels: int,
-              layers: Tuple[int, ...] or List[int],
+              layers: Union[Tuple[int, ...], List[int]],
               batch_norm=False,
-              activation: str or Callable = 'ReLU',
+              activation: Union[str, Callable] = 'ReLU',
               softmax=False) -> nn.Module:
     """
     Fully-connected neural networks are available in Φ-Flow via dense_net().
@@ -217,10 +217,10 @@ class DenseNet(nn.Module):
 def u_net(in_channels: int,
           out_channels: int,
           levels: int = 4,
-          filters: int or tuple or list = 16,
+          filters: Union[int, tuple, list] = 16,
           batch_norm: bool = True,
-          activation: str or type = 'ReLU',
-          in_spatial: tuple or int = 2,
+          activation: Union[str, type] = 'ReLU',
+          in_spatial: Union[tuple, int] = 2,
           periodic=False,
           use_res_blocks: bool = False,
           **kwargs) -> nn.Module:
@@ -310,7 +310,7 @@ MAX_POOL = [None, nn.MaxPool1d, nn.MaxPool2d, nn.MaxPool3d]
 class Down(nn.Module):
     """Downscaling with maxpool then double conv or resnet_block"""
 
-    def __init__(self, d: int, in_channels: int, out_channels: int, batch_norm: bool, activation: str or type, use_res_blocks: bool, periodic):
+    def __init__(self, d: int, in_channels: int, out_channels: int, batch_norm: bool, activation: Union[str, type], use_res_blocks: bool, periodic):
         super().__init__()
         self.add_module('maxpool', MAX_POOL[d](2))
         if use_res_blocks:
@@ -380,10 +380,10 @@ class ConvNet(nn.Module):
 
 def conv_net(in_channels: int,
              out_channels: int,
-             layers: Tuple[int, ...] or List[int],
+             layers: Union[Tuple[int, ...], List[int]],
              batch_norm: bool = False,
-             activation: str or type = 'ReLU',
-             in_spatial: int or tuple = 2,
+             activation: Union[str, type] = 'ReLU',
+             in_spatial: Union[int, tuple] = 2,
              periodic=False,
              **kwargs) -> nn.Module:
     """
@@ -515,10 +515,10 @@ class ResNet(nn.Module):
 
 def res_net(in_channels: int,
             out_channels: int,
-            layers: Tuple[int, ...] or List[int],
+            layers: Union[Tuple[int, ...], List[int]],
             batch_norm: bool = False,
-            activation: str or type = 'ReLU',
-            in_spatial: int or tuple = 2,
+            activation: Union[str, type] = 'ReLU',
+            in_spatial: Union[int, tuple] = 2,
             periodic=False,
             **kwargs) -> nn.Module:
     """
@@ -551,7 +551,7 @@ def res_net(in_channels: int,
 
 
 def conv_classifier(in_features: int,
-                    in_spatial: tuple or list,
+                    in_spatial: Union[tuple, list],
                     num_classes: int,
                     blocks=(64, 128, 256, 256, 512, 512),
                     dense_layers=(4096, 4096, 100),
@@ -672,8 +672,8 @@ def invertible_net(in_channels: int,
                    num_blocks: int,
                    batch_norm: bool = False,
                    net: str = 'u_net',
-                   activation: str or type = 'ReLU',
-                   in_spatial: tuple or int = 2, **kwargs):
+                   activation: Union[str, type] = 'ReLU',
+                   in_spatial: Union[tuple, int] = 2, **kwargs):
     """
     Phiflow also provides invertible neural networks that are capable of inverting the output tensor back to the input tensor initially passed.\ These networks have far reaching applications in predicting input parameters of a problem given its observations.\ Invertible nets are composed of multiple concatenated coupling blocks wherein each such block consists of arbitrary neural networks.
 
@@ -704,10 +704,10 @@ def invertible_net(in_channels: int,
 
 
 def coupling_layer(in_channels: int,
-                   activation: str or type = 'ReLU',
+                   activation: Union[str, type] = 'ReLU',
                    batch_norm=False,
                    reverse_mask=False,
-                   in_spatial: tuple or int = 2):
+                   in_spatial: Union[tuple, int] = 2):
     if isinstance(in_spatial, tuple):
         in_spatial = len(in_spatial)
 
@@ -881,8 +881,8 @@ class FNO(nn.Module):
 def fno(in_channels: int,
         out_channels: int,
         mid_channels: int,
-        modes: Tuple[int, ...] or List[int],
-        activation: str or type = 'ReLU',
+        modes: Union[Tuple[int, ...], List[int]],
+        activation: Union[str, type] = 'ReLU',
         batch_norm: bool = False,
         in_spatial: int = 2):
     """

--- a/phi/vis/_dash/_plotly_plots.py
+++ b/phi/vis/_dash/_plotly_plots.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Tuple, Any, Dict, List, Callable
+from typing import Tuple, Any, Dict, List, Callable, Union
 
 import numpy
 import numpy as np
@@ -378,7 +378,7 @@ def get_color_interpolation(val, cm_arr):
     return center
 
 
-def plot_scalars(curves: tuple or list, labels, subplots=True, log_scale='', smooth: int = 1):
+def plot_scalars(curves: Union[tuple, list], labels, subplots=True, log_scale='', smooth: int = 1):
     if not curves:
         return graph_objects.Figure()
     if subplots:

--- a/phi/vis/_dash/player_controls.py
+++ b/phi/vis/_dash/player_controls.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 import dash_core_components as dcc
 import dash_html_components as html
 from dash.dependencies import Output, Input, State
@@ -80,7 +82,7 @@ def build_player_controls(app: DashApp):
     return layout
 
 
-def parse_step_count(step_count, app, default: int or None = 1):
+def parse_step_count(step_count, app, default: Union[int, None] = 1):
     if step_count is None:
         return default
     try:

--- a/phi/vis/_log.py
+++ b/phi/vis/_log.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 from os.path import isfile
+from typing import Union
 
 import numpy as np
 
@@ -43,7 +44,7 @@ class SceneLog:
     def log(self, message):
         self.logger.info(message)
 
-    def log_scalars(self, frame: int, **values: float or math.Tensor):
+    def log_scalars(self, frame: int, **values: Union[float, math.Tensor]):
         """
         Adds `values` to the curves by name.
         This can be used to log the evolution of scalar quantities or summaries.

--- a/phi/vis/_matplotlib/_matplotlib_plots.py
+++ b/phi/vis/_matplotlib/_matplotlib_plots.py
@@ -1,6 +1,6 @@
 import sys
 import warnings
-from typing import Callable, Tuple, Any, Dict
+from typing import Callable, Tuple, Any, Dict, Union
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -419,7 +419,7 @@ def _plt_col(col):
     return col
 
 
-def matplotlib_colors(color: Tensor, dims: Shape, default=None) -> list or None:
+def matplotlib_colors(color: Tensor, dims: Shape, default=None) -> Union[list, None]:
     if color.rank == 0 and color.native() is None:
         if default is None:
             return None

--- a/phi/vis/_matplotlib/_scalars.py
+++ b/phi/vis/_matplotlib/_scalars.py
@@ -1,6 +1,6 @@
 import os
 from numbers import Number
-from typing import Callable
+from typing import Callable, Union
 
 import matplotlib.pyplot as plt
 import numpy
@@ -16,9 +16,9 @@ from phi.vis._vis_base import display_name
 from ._matplotlib_plots import MATPLOTLIB
 
 
-def plot_scalars(scene: str or tuple or list or Scene or math.Tensor,
-                 names: str or tuple or list or math.Tensor = None,
-                 reduce: str or tuple or list or math.Shape = 'names',
+def plot_scalars(scene: Union[str, tuple, list, Scene, math.Tensor],
+                 names: Union[str, tuple, list, math.Tensor] = None,
+                 reduce: Union[str, tuple, list, math.Shape] = 'names',
                  down='',
                  smooth=1,
                  smooth_alpha=0.2,
@@ -26,7 +26,7 @@ def plot_scalars(scene: str or tuple or list or Scene or math.Tensor,
                  size=(8, 6),
                  transform: Callable = None,
                  tight_layout=True,
-                 grid: str or dict = 'y',
+                 grid: Union[str, dict] = 'y',
                  log_scale='',
                  legend='upper right',
                  x='steps',

--- a/phi/vis/_viewer.py
+++ b/phi/vis/_viewer.py
@@ -4,7 +4,7 @@ import time
 import warnings
 from functools import partial
 from threading import Event
-from typing import Tuple
+from typing import Tuple, Union
 
 from ._log import SceneLog
 from ._user_namespace import UserNamespace
@@ -19,7 +19,7 @@ def create_viewer(namespace: UserNamespace,
                   fields: dict,
                   name: str,
                   description: str,
-                  scene: Scene or None,
+                  scene: Union[Scene, None],
                   asynchronous: bool,
                   controls: tuple,
                   actions: dict,
@@ -277,7 +277,7 @@ class AsyncViewer(Viewer):
 
 class Record:
 
-    def __init__(self, dim: str or None):
+    def __init__(self, dim: Union[str, None]):
         self.dim = dim
         self.history = {}
 

--- a/phi/vis/_vis.py
+++ b/phi/vis/_vis.py
@@ -4,7 +4,7 @@ import sys
 import warnings
 from contextlib import contextmanager
 from threading import Thread
-from typing import Tuple, List, Dict
+from typing import Tuple, List, Dict, Union
 
 from ._user_namespace import get_user_namespace, UserNamespace, DictNamespace
 from ._viewer import create_viewer, Viewer
@@ -17,10 +17,10 @@ from ..math import Tensor, layout, batch, Shape, wrap, merge_shapes, EMPTY_SHAPE
 from ..math._shape import parse_dim_order, DimFilter
 
 
-def show(*model: VisModel or SampledField or tuple or list or Tensor or Geometry,
+def show(*model: Union[VisModel, SampledField, tuple, list, Tensor, Geometry],
          play=True,
-         gui: Gui or str = None,
-         lib: Gui or str = None,
+         gui: Union[Gui, str] = None,
+         lib: Union[Gui, str] = None,
          keep_alive=True,
          **config):
     """
@@ -100,7 +100,7 @@ def close(figure=None):
 RECORDINGS = {}
 
 
-def record(*fields: str or SampledField) -> Viewer:
+def record(*fields: Union[str, SampledField]) -> Viewer:
     user_namespace = get_user_namespace(1)
     variables = _default_field_variables(user_namespace, fields)
     viewer = create_viewer(user_namespace, variables, "record", "", scene=None, asynchronous=False, controls=(),
@@ -110,14 +110,14 @@ def record(*fields: str or SampledField) -> Viewer:
     return viewer
 
 
-def view(*fields: str or SampledField,
+def view(*fields: Union[str, SampledField],
          play: bool = True,
          gui=None,
          name: str = None,
          description: str = None,
-         scene: bool or Scene = False,
+         scene: Union[bool, Scene] = False,
          keep_alive=True,
-         select: str or tuple or list = '',
+         select: Union[str, tuple, list] = '',
          framerate=None,
          namespace=None,
          log_performance=True,
@@ -266,19 +266,19 @@ def get_current_figure():
     return LAST_FIGURE[0]
 
 
-def plot(*fields: SampledField or Tensor,
-         lib: str or PlottingLibrary = None,
+def plot(*fields: Union[SampledField, Tensor],
+         lib: Union[str, PlottingLibrary] = None,
          row_dims: DimFilter = None,
          col_dims: DimFilter = batch,
          animate: DimFilter = None,
          overlay: DimFilter = 'overlay',
-         title: str or Tensor = None,
+         title: Union[str, Tensor] = None,
          size=(12, 5),
          same_scale=True,
-         log_dims: str or tuple or list or Shape = '',
+         log_dims: Union[str, tuple, list, Shape] = '',
          show_color_bar=True,
-         color: str or int or Tensor = None,
-         alpha: float or Tensor = 1.,
+         color: Union[str, int, Tensor] = None,
+         alpha: Union[float, Tensor] = 1.,
          frame_time=100,
          repeat=True):
     """
@@ -389,7 +389,7 @@ def layout_pytree_node(data, wrap_leaf=False):
     return wrap(data) if wrap_leaf else data
 
 
-def layout_sub_figures(data: Tensor or SampledField,
+def layout_sub_figures(data: Union[Tensor, SampledField],
                        row_dims: DimFilter,
                        col_dims: DimFilter,
                        animate: DimFilter,  # do not reduce these dims, has priority
@@ -398,7 +398,7 @@ def layout_sub_figures(data: Tensor or SampledField,
                        offset_col: int,
                        positioning: Dict[Tuple[int, int], List],
                        indices: Dict[Tuple[int, int], List[dict]],
-                       base_index: Dict[str, int or str]) -> Tuple[int, int, Shape, Shape]:  # rows, cols
+                       base_index: Dict[str, Union[int, str]]) -> Tuple[int, int, Shape, Shape]:  # rows, cols
     if data is None:
         raise ValueError(f"Cannot layout figure for '{data}'")
     data = layout_pytree_node(data)
@@ -470,7 +470,7 @@ def _space(fields: Tuple[Field, ...], ignore_dims: Shape) -> Box:
     return Box(lower, upper)
 
 
-def overlay(*fields: SampledField or Tensor) -> Tensor:
+def overlay(*fields: Union[SampledField, Tensor]) -> Tensor:
     """
     Specify that multiple fields should be drawn on top of one another in the same figure.
     The fields will be plotted in the order they are given, i.e. the last field on top.
@@ -518,7 +518,7 @@ def default_gui() -> Gui:
     raise RuntimeError("No user interface available.")
 
 
-def get_gui(gui: str or Gui) -> Gui:
+def get_gui(gui: Union[str, Gui]) -> Gui:
     if GUI_OVERRIDES:
         return GUI_OVERRIDES[-1]
     if isinstance(gui, str):
@@ -564,7 +564,7 @@ def default_plots() -> PlottingLibrary:
     raise RuntimeError("No user interface available.")
 
 
-def get_plots(lib: str or PlottingLibrary) -> PlottingLibrary:
+def get_plots(lib: Union[str, PlottingLibrary]) -> PlottingLibrary:
     if isinstance(lib, PlottingLibrary):
         return lib
     for loaded_lib in _LOADED_PLOTTING_LIBRARIES:

--- a/phi/vis/_vis_base.py
+++ b/phi/vis/_vis_base.py
@@ -3,7 +3,7 @@ import time
 from collections import namedtuple
 from math import log10
 from threading import Lock
-from typing import Tuple, Any, Optional, Dict, Callable
+from typing import Tuple, Any, Optional, Dict, Callable, Union
 
 from phi import field, math
 from phi.field import SampledField, Scene, PointCloud, CenteredGrid
@@ -221,7 +221,7 @@ class AsyncPlay:
         return status_message(self.model, self)
 
 
-def status_message(model: VisModel, play_status: AsyncPlay or None):
+def status_message(model: VisModel, play_status: Union[AsyncPlay, None]):
     pausing = "/Pausing" if (play_status and play_status.paused) else ""
     current_action = "Running" if model.is_progressing else "Waiting"
     action = current_action if play_status else "Idle"
@@ -322,7 +322,7 @@ class Gui:
 
 class PlottingLibrary:
 
-    def __init__(self, name: str, figure_classes: tuple or list):
+    def __init__(self, name: str, figure_classes: Union[tuple, list]):
         self.name = name
         self.figure_classes = tuple(figure_classes)
         self.current_figure = None
@@ -428,7 +428,7 @@ def display_name(python_name: Any):
         return text
 
 
-def index_label(idx: dict) -> str or None:
+def index_label(idx: dict) -> Union[str, None]:
     if len(idx) == 0:
         return None
     elif len(idx) == 1:
@@ -460,7 +460,7 @@ def common_index(*indices: dict, exclude=()):
     return {k: v for k, v in indices[0].items() if k not in exclude and all(i[k] == v for i in indices)}
 
 
-def select_channel(value: SampledField or Tensor or tuple or list, channel: str or None):
+def select_channel(value: Union[SampledField, Tensor, tuple, list], channel: Union[str, None]):
     if isinstance(value, (tuple, list)):
         return [select_channel(v, channel) for v in value]
     if channel is None:


### PR DESCRIPTION
Python evaluates the expressions in function declarations when the module loads, so

```
def f(x: Tensor or float):
    pass
```

evaluates to

```
def f(x: Tensor):
    pass
```

since `Tensor or float` evaluates to `float` (Python's `or` operator [short circuits](https://stackoverflow.com/a/14892812/11324994) and returns the first argument that is truthy). This results in the type hints in PhiFlow being wrong when evaluated by an IDE.

I have contributed some changes to replace `type1 or type2 or ...` with `typing.Union[type1, type2, ...]`, which is the correct approach. This took way too long, but should improve useability in IDEs with type inference. I will continue to contribute missing types to make the typing system more robust.

From Python 3.10 and onward there is a [new way of doing this](https://peps.python.org/pep-0604/) that looks much cleaner, but for now I think `Union` is the best approach.