### PR TITLE
[geom] add intersection mode to GeometryStack

### DIFF
--- a/docs/Geometry.md
+++ b/docs/Geometry.md
@@ -51,6 +51,8 @@ Rotation: `geometry.rotate(angle)`
 
 Union: `union(geometries)`
 
+Intersection: `intersection(geometries)`
+
 Geometries can be inverted using the `~` operator, i.e. the results of 
 `lies_inside`, `approximate_signed_distance` and `approximate_fraction_inside` return the inverse values.
 

--- a/phi/geom/__init__.py
+++ b/phi/geom/__init__.py
@@ -20,6 +20,6 @@ from ._mesh import Mesh, mesh, load_su2, load_gmsh, mesh_from_numpy, build_mesh
 from ._transform import embed, infinite_cylinder
 from ._heightmap import Heightmap
 from ._sdf_grid import SDFGrid, sdf_from_geometry
-from ._geom_ops import union
+from ._geom_ops import union, intersection
 
 __all__ = [key for key in globals().keys() if not key.startswith('_')]

--- a/phi/geom/_geom.py
+++ b/phi/geom/_geom.py
@@ -451,7 +451,8 @@ class Geometry:
             return NotImplemented  # let attributes be stacked
         else:
             from ._geom_ops import GeometryStack
-            return GeometryStack(math.layout(values, dim))
+            set_op = kwargs.get('set_op')
+            return GeometryStack(math.layout(values, dim), set_op)
 
     def __flatten__(self, flat_dim: Shape, flatten_batch: bool, **kwargs) -> 'Geometry':
         dims = self.shape.without('vector')

--- a/phi/geom/_geom_ops.py
+++ b/phi/geom/_geom_ops.py
@@ -1,5 +1,6 @@
+from numbers import Number
 import warnings
-from typing import Union, Dict, Any, Sequence, Tuple
+from typing import Union, Dict, Any, Optional, Tuple
 
 from phi import math
 from phiml import math
@@ -22,7 +23,7 @@ class GeometryStack(Geometry):
     Instance dimensions represent geometry unions and are reduced.
     """
 
-    def __init__(self, geometries: Union[Tensor, Geometry]):
+    def __init__(self, geometries: Union[Tensor, Geometry], set_op: Optional[str]=None):
         """
         Args:
             geometries: Tensor[Geometry] with one or multiple dimensions of any type.
@@ -31,10 +32,18 @@ class GeometryStack(Geometry):
         ranks = wrap(math.map(lambda g: g.spatial_rank, geometries, dims=object))
         assert ranks.min == ranks.max, f"Can only stack geometries of the same spatial rank but got ranks {ranks}"
         self._shape = geometries.shape
+        if set_op is None:
+            set_op = 'union'
+        assert set_op in ['union', 'intersection'], f"Set operation must be 'union' or 'intersection' but got {set_op}"
+        self._set_op = set_op
 
     @property
     def geometries(self):
         return self._geometries
+    
+    @property
+    def set_op(self):
+        return self._set_op
 
     def __variable_attrs__(self):
         return '_geometries',
@@ -54,6 +63,8 @@ class GeometryStack(Geometry):
             raise NotImplementedError()
 
     def _bounding_box(self):
+        if self._set_op == 'intersection':
+            raise NotImplementedError
         boxes = math.map(bounding_box, self._geometries, dims=object)
         lower = math.min(boxes.lower, instance)
         upper = math.max(boxes.upper, instance)
@@ -61,6 +72,16 @@ class GeometryStack(Geometry):
 
     @property
     def center(self) -> Tensor:
+        if self._set_op == 'intersection':
+            centers = math.map(lambda g: g.center, self._geometries, dims=object)
+            if not instance(centers):
+                return centers
+            # --- bounding box of smallest volume ---
+            warnings.warn("Center of an intersection assumes geometries are subsets of each larger geometry and may not be accurate otherwise.", RuntimeWarning)
+            vol = math.map(lambda g: g.volume, self._geometries, dims=object)
+            boxes = math.map(bounding_box, self._geometries, dims=object)
+            smallest_vol_idx = math.argmin(vol, instance)
+            return boxes[smallest_vol_idx].center
         return self._bounding_box().center
 
     @property
@@ -83,23 +104,49 @@ class GeometryStack(Geometry):
     @property
     def volume(self) -> math.Tensor:
         if instance(self._geometries):
-            warnings.warn("Volume of a union assumes geometries do not overlap and may not be accurate otherwise.", RuntimeWarning)
+            if self._set_op == 'intersection':
+                warn_msg = "Volume of an intersection assumes geometries are subsets of each larger geometry and may not be accurate otherwise."
+            else:
+                warn_msg = "Volume of a union assumes geometries do not overlap and may not be accurate otherwise."
+            warnings.warn(warn_msg, RuntimeWarning)
         vol = math.map(lambda g: g.volume, self._geometries, dims=object)
+        if self._set_op == 'intersection':
+            return math.min(vol, instance(self._geometries))
         return math.sum(vol, instance(self._geometries))
 
     def lies_inside(self, location: math.Tensor):
         inside = math.map(lambda g, l: g.lies_inside(l), self._geometries, location, dims=object)
+        if self._set_op == 'intersection':
+            return math.all(inside, instance(self._geometries))
         return math.any(inside, instance(self._geometries))
 
     def approximate_signed_distance(self, location: math.Tensor):
+        if self._set_op == 'intersection':
+            raise NotImplementedError
         dist = math.map(lambda g, l: g.approximate_signed_distance(l), self._geometries, location, dims=object)
         return math.min(dist, instance(self._geometries))
 
+    def approximate_fraction_inside(self, other_geometry: Geometry, balance: Tensor | Number = 0.5) -> Tensor:
+        if self._set_op == 'intersection':
+            assert isinstance(other_geometry, Geometry)
+            radius = other_geometry.bounding_radius()
+            location = other_geometry.center
+            distances = math.map(lambda g: g.approximate_signed_distance(location), self._geometries, dims=object)
+            inside_fraction = balance - distances / radius
+            inside_fraction = math.clip(inside_fraction, 0, 1)
+            inside_fraction = math.min(inside_fraction, instance(self._geometries))
+            return inside_fraction
+        return super().approximate_fraction_inside(other_geometry, balance)
+
     def approximate_closest_surface(self, location: Tensor) -> Tuple[Tensor, Tensor, Tensor, Tensor, Tensor]:
+        if self._set_op == 'intersection':
+            raise NotImplementedError
         signed_dist, delta, normals, offsets, face_idx = math.map(lambda g, l: g.approximate_closest_surface(l), self._geometries, location, dims=object)
         return math.at_min((signed_dist, delta, normals, offsets, face_idx), key=abs(signed_dist), dim=instance)
 
     def bounding_radius(self):
+        if self._set_op == 'intersection':
+            raise NotImplementedError
         center = self.center
         rad = math.map(lambda g: math.vec_length(g.center - center) + g.bounding_radius(), self._geometries, dims=object)
         return math.max(rad, instance(self._geometries))
@@ -108,24 +155,25 @@ class GeometryStack(Geometry):
         return self._bounding_box().half_size
 
     def shifted(self, delta: Tensor) -> 'Geometry':
-        return GeometryStack(math.map(lambda g: g.shifted(delta), self._geometries, dims=object))
+        return GeometryStack(math.map(lambda g: g.shifted(delta), self._geometries, dims=object), set_op=self._set_op)
 
     def at(self, center: Tensor) -> 'Geometry':
         return self.shifted(center - self.center)
 
     def rotated(self, angle):
         pivot = self.center
-        return GeometryStack(math.map(lambda g: rotate(g, angle, pivot), self._geometries, dims=object))
+        return GeometryStack(math.map(lambda g: rotate(g, angle, pivot), self._geometries, dims=object), set_op=self._set_op)
 
     def __eq__(self, other):
         return isinstance(other, GeometryStack) \
                and self._shape == other._shape \
-               and (self.geometries == other.geometries).all
+               and (self.geometries == other.geometries).all \
+               and (self._set_op == other.set_op)
 
     def shallow_equals(self, other):
         if self is other:
             return True
-        if not isinstance(other, GeometryStack) or self._geometries.shape != other._geometries.shape:
+        if not isinstance(other, GeometryStack) or self._geometries.shape != other.geometries.shape or self._set_op != other.set_op:
             return False
         return all(g1.shallow_equals(g2) for g1, g2 in zip(self.geometries, other.geometries))
 
@@ -137,7 +185,7 @@ class GeometryStack(Geometry):
         if isinstance(selected, Geometry):
             return selected
         else:
-            return GeometryStack(selected)
+            return GeometryStack(selected, set_op=self._set_op)
 
     @property
     def faces(self) -> 'Geometry':
@@ -145,18 +193,26 @@ class GeometryStack(Geometry):
 
     @property
     def face_centers(self) -> Tensor:
+        if self._set_op == 'intersection':
+            raise NotImplementedError
         return math.map(lambda g: g.face_centers, self._geometries, dims=object)
 
     @property
     def face_areas(self) -> Tensor:
+        if self._set_op == 'intersection':
+            raise NotImplementedError
         return math.map(lambda g: g.face_areas, self._geometries, dims=object)
 
     @property
     def face_normals(self) -> Tensor:
+        if self._set_op == 'intersection':
+            raise NotImplementedError
         return math.map(lambda g: g.face_normals, self._geometries, dims=object)
 
     @property
     def boundary_elements(self) -> Dict[Any, Dict[str, slice]]:
+        if self._set_op == 'intersection':
+            raise NotImplementedError
         result = {}
         for idx in object_dims(self._geometries).meshgrid(names=True):
             elements = self._geometries[idx].boundary_elements
@@ -174,6 +230,8 @@ class GeometryStack(Geometry):
 
     @property
     def face_shape(self) -> Shape:
+        if self._set_op == 'intersection':
+            raise NotImplementedError
         face_shapes = [g.face_shape for g in self.geometries]
         return shape_stack(self.geometries.shape, *face_shapes)
 
@@ -183,6 +241,28 @@ class GeometryStack(Geometry):
     def scaled(self, factor: Union[float, Tensor]) -> 'Geometry':
         raise NotImplementedError
 
+def _stack_geometries(geometries: Tuple[Geometry], set_op: str, dim=None) -> Geometry:
+    assert set_op in ['union', 'intersection'], f"Set operation must be 'union' or 'intersection' but got {set_op}"
+    if dim is None:
+        dim = instance(set_op)
+    assert dim.rank == 1 and dim.instance, f"{set_op} dimension must be a single instance dimension but got {dim}"
+    if len(geometries) == 1 and isinstance(geometries[0], (tuple, list)):
+        geometries = geometries[0]
+    if len(geometries) == 0:
+        return NO_GEOMETRY
+    elif len(geometries) == 1:
+        return geometries[0]
+    elif set_op == 'union' and all(type(g) == type(geometries[0]) and isinstance(g, PhiTreeNode) for g in geometries):
+        # ToDo look into using stacked attributes for intersection
+        attrs = variable_attributes(geometries[0])
+        values = {a: math.stack([getattr(g, a) for g in geometries], dim) for a in attrs}
+        return copy_with(geometries[0], **values)
+    else:
+        # ToDo group by type, union individual types along union_<type>, then stack the groups
+        base_geometries = ()
+        for geometry in geometries:
+            base_geometries += (geometry,)
+        return math.stack(base_geometries, dim, set_op=set_op)
 
 def union(*geometries, dim=instance('union')) -> Geometry:
     """
@@ -196,26 +276,27 @@ def union(*geometries, dim=instance('union')) -> Geometry:
     Returns:
         union `Geometry`
     """
-    assert dim.rank == 1 and dim.instance, f"union dimension must be a single instance dimension but got {dim}"
-    if len(geometries) == 1 and isinstance(geometries[0], (tuple, list)):
-        geometries = geometries[0]
-    if len(geometries) == 0:
-        return NO_GEOMETRY
-    elif len(geometries) == 1:
-        return geometries[0]
-    elif all(type(g) == type(geometries[0]) and isinstance(g, PhiTreeNode) for g in geometries):
-        attrs = variable_attributes(geometries[0])
-        values = {a: math.stack([getattr(g, a) for g in geometries], dim) for a in attrs}
-        return copy_with(geometries[0], **values)
-    else:
-        # ToDo group by type, union individual types along union_<type>, then stack the groups
-        base_geometries = ()
-        for geometry in geometries:
-            base_geometries += (geometry,)
-        return math.stack(base_geometries, dim)
+    return _stack_geometries(geometries, 'union', dim)
+
+def intersection(*geometries, dim=instance('intersection')) -> Geometry:
+    """
+    Intersection of the given geometries.
+    A point lies inside the union if it lies within all of the geometries.
+
+    Args:
+        *geometries: arbitrary geometries with same spatial dims. Arbitrary batch dims are allowed.
+        dim: Intersection dimension. This must be an instance dimension.
+
+    Returns:
+        intersection `Geometry`
+    """
+    return _stack_geometries(geometries, 'intersection', dim)
 
 
 Geometry.__add__ = lambda g1, g2: union(g1, g2)
+Geometry.__mul__ = lambda g1, g2: intersection(g1, g2)
+Geometry.__or__ = lambda g1, g2: union(g1, g2)
+Geometry.__and__ = lambda g1, g2: intersection(g1, g2)
 
 
 def expel(geometry: Geometry,

--- a/phi/geom/_grid.py
+++ b/phi/geom/_grid.py
@@ -154,7 +154,8 @@ class UniformGrid(BaseBox):
     @staticmethod
     def __stack__(values: tuple, dim: Shape, **kwargs) -> 'Geometry':
         from ._geom_ops import GeometryStack
-        return GeometryStack(math.layout(values, dim))
+        set_op = kwargs.get('set_op')
+        return GeometryStack(math.layout(values, dim), set_op)
 
     def __replace_dims__(self, dims: Tuple[str, ...], new_dims: Shape, **kwargs) -> 'UniformGrid':
         resolution = math.rename_dims(self._resolution, dims, new_dims).spatial

--- a/tests/commit/geom/test_geom.py
+++ b/tests/commit/geom/test_geom.py
@@ -54,3 +54,14 @@ class TestGeom(TestCase):
         self.assertEqual(channel(vector='x,y'), u.shape['vector'])
         math.assert_close(1 + 3.1415927, u.volume)
         math.assert_close(True, u.lies_inside(vec(x=0, y=0)))
+
+    def test_intersection(self):
+        u = geom.intersection(Box(x=1, y=1), Sphere(x=0, y=0, radius=1))
+        print(u)
+        math.assert_close(vec(x=0.5, y=0.5), u.center)
+        self.assertEqual(2, u.spatial_rank)
+        self.assertEqual(channel(vector='x,y'), u.shape['vector'])
+        math.assert_close(1, u.volume)
+        math.assert_close(False, u.lies_inside(vec(x=0.5, y=-0.5)))
+        math.assert_close(True, u.lies_inside(vec(x=0.5, y=0.5)))
+        math.assert_close(False, u.lies_inside(vec(x=0.9, y=0.9)))


### PR DESCRIPTION
A supplement to the existing `union()` function.

Most code changes are in `phi/geom/_geom_ops.py`. Includes unit tests and documentation update. Intersection uses the `GeometryStack` class but adds a new parameter `set_op` to the `__init__()` method.

Like `union()`, a few functions and properties including `volume`, `faces`, and `sample_uniform()` are either not implemented or only approximately implemented. `GeometryStack` objects created with `intersection()` include `RuntimeWarning`s as appropriate based on the pattern of `union()`.

Here is a sample (based on Wake Flow) showing the intersection of a box and a sphere in a flowing fluid, creating an oval-like shape:

![curl](https://github.com/user-attachments/assets/b9cd8ef5-eec1-45c3-9c51-baeeb3db27e2)