### PR TITLE
Modify eps to improve code usability

### DIFF
--- a/phi/geom/_sphere.py
+++ b/phi/geom/_sphere.py
@@ -116,7 +116,7 @@ class Sphere(Geometry, metaclass=SphereType):
           float tensor of shape (*location.shape[:-1], 1).
 
         """
-        distance = vec_length(location - self.pos, eps=1e-3)
+        distance = vec_length(location - self.pos, eps=1e-9)
         return math.min(distance - self.radius, self.shape.instance)  # union for instance dimensions
 
     def approximate_closest_surface(self, location: Tensor) -> Tuple[Tensor, Tensor, Tensor, Tensor, Tensor]:


### PR DESCRIPTION
The original setting for Sphere.approximate_signed_distance was eps=1e-3, which would cause SDF calculation errors for small-radius cylinders (such as radius=0.025).