### PR TITLE
Add wave equation module (phi.physics.wave)

### DIFF
--- a/demos/wave_equation.py
+++ b/demos/wave_equation.py
@@ -1,0 +1,33 @@
+"""
+Wave equation demo using PhiFlow.
+
+Simulates a 2D wave equation ∂²u/∂t² = c² ∇²u on a square domain
+starting from a Gaussian pulse, using the leapfrog scheme from
+phi.physics.wave.
+"""
+from phi.flow import *
+from phi.physics import wave
+
+# --- Parameters ---
+N = 128
+DT = 0.002
+C = 1.0
+STEPS = 500
+
+# --- Initial condition: Gaussian pulse centered in domain, at rest ---
+u = CenteredGrid(
+    lambda x: math.exp(-100 * math.vec_squared(x - 0.5)),
+    extrapolation.ZERO_GRADIENT,
+    x=N, y=N,
+    bounds=Box(x=1, y=1)
+)
+u_prev = u  # zero initial velocity (du/dt = 0)
+
+# --- Time integration with leapfrog ---
+for step_i in range(STEPS):
+    u, u_prev = wave.step(u, u_prev, c=C, dt=DT)
+
+# --- Report ---
+print(f"Wave equation simulation completed: {STEPS} steps, grid {N}x{N}")
+print(f"  dt={DT}, c={C}, CFL = {C * DT / (1.0 / N):.3f}")
+print(f"  Final field: min={float(math.min(u.values)):.6f}, max={float(math.max(u.values)):.6f}")

--- a/phi/physics/wave.py
+++ b/phi/physics/wave.py
@@ -1,0 +1,115 @@
+"""
+Functions for simulating the wave equation on `phi.field.Field` objects.
+
+Provides explicit leapfrog and Euler time integration for the scalar wave equation:
+
+    ∂²u/∂t² = c² ∇²u
+
+where u is the wave amplitude and c is the wave speed.
+"""
+from typing import Union
+
+from phi import math
+from phi.field import Field, laplace
+from phiml.math import Tensor, wrap, spatial
+
+
+def step(u: Field,
+         u_prev: Field,
+         c: Union[float, Tensor, Field] = 1.,
+         dt: Union[float, Tensor] = 1.,
+         source: Field = None) -> tuple:
+    """
+    Advance the wave equation by one time step using leapfrog (Verlet) integration.
+
+    Solves ∂²u/∂t² = c² ∇²u + f where u is the wave amplitude, c is the wave speed,
+    and f is an optional source term.
+
+    This scheme is second-order accurate in both space and time and preserves energy.
+
+    Args:
+        u: Current wave amplitude as a `CenteredGrid` or other `Field`.
+        u_prev: Wave amplitude at the previous time step.
+        c: Wave speed. Can be a constant, `Tensor`, or spatially varying `Field`.
+        dt: Time step size.
+        source: Optional source term f(x, t) as a `Field`.
+
+    Returns:
+        Tuple of `(u_next, u)` where `u_next` is the amplitude at the new time step.
+        Pass these as `(u, u_prev)` to advance again.
+
+    Examples:
+        >>> from phi.flow import *
+        >>> u = CenteredGrid(Noise(), x=64, y=64, bounds=Box(x=1, y=1))
+        >>> u_prev = u  # start from rest
+        >>> u_next, u = wave.step(u, u_prev, c=1.0, dt=0.01)
+    """
+    c_sq = c * c if not isinstance(c, Field) else c * c
+    acceleration = c_sq * laplace(u)
+    if source is not None:
+        acceleration = acceleration + source
+    u_next = 2 * u - u_prev + dt * dt * acceleration
+    return u_next, u
+
+
+def euler_step(u: Field,
+               v: Field,
+               c: Union[float, Tensor, Field] = 1.,
+               dt: Union[float, Tensor] = 1.,
+               source: Field = None) -> tuple:
+    """
+    Advance the wave equation by one time step using symplectic Euler integration.
+
+    Solves the first-order system:
+        ∂u/∂t = v
+        ∂v/∂t = c² ∇²u + f
+
+    This is useful when the initial velocity v = ∂u/∂t is known directly.
+
+    Args:
+        u: Current wave amplitude as a `Field`.
+        v: Current velocity (time derivative of u) as a `Field`.
+        c: Wave speed. Can be a constant, `Tensor`, or spatially varying `Field`.
+        dt: Time step size.
+        source: Optional source term f(x, t) as a `Field`.
+
+    Returns:
+        Tuple of `(u_next, v_next)` for the next time step.
+
+    Examples:
+        >>> from phi.flow import *
+        >>> u = CenteredGrid(0, x=64, y=64, bounds=Box(x=1, y=1))
+        >>> v = CenteredGrid(Noise(), x=64, y=64, bounds=Box(x=1, y=1))
+        >>> u_next, v_next = wave.euler_step(u, v, c=1.0, dt=0.01)
+    """
+    c_sq = c * c if not isinstance(c, Field) else c * c
+    acceleration = c_sq * laplace(u)
+    if source is not None:
+        acceleration = acceleration + source
+    v_next = v + dt * acceleration
+    u_next = u + dt * v_next
+    return u_next, v_next
+
+
+def differential(u: Field,
+                 c: Union[float, Tensor, Field] = 1.,
+                 source: Field = None) -> Field:
+    """
+    Compute the acceleration term c² ∇²u + f without advancing time.
+
+    This is the right-hand side of ∂²u/∂t² = c² ∇²u + f and can be used
+    with custom time integrators such as `phi.physics.integrate.rk4`.
+
+    Args:
+        u: Wave amplitude as a `Field`.
+        c: Wave speed.
+        source: Optional source term.
+
+    Returns:
+        Acceleration field ∂²u/∂t² as a `Field`.
+    """
+    c_sq = c * c if not isinstance(c, Field) else c * c
+    result = c_sq * laplace(u)
+    if source is not None:
+        result = result + source
+    return result


### PR DESCRIPTION
## Summary

Adds a phi.physics.wave module for simulating the scalar wave equation:

feature/add-wave-equation\frac{\partial^2 u}{\partial t^2} = c^2 \nabla^2 u + ffeature/add-wave-equation

This fills a gap in the physics module collection, which currently covers advection, diffusion, and fluid dynamics but has no wave equation support.

## New Files

### `phi/physics/wave.py`
Three functions following the same Field-based API patterns as `phi.physics.diffuse`:

- **`step(u, u_prev, c, dt)`** — Leapfrog (Verlet) integration. Energy-conserving, second-order in space and time. Returns `(u_next, u)` for chaining.
- **`euler_step(u, v, c, dt)`** — Symplectic Euler when initial velocity is known directly. Returns `(u_next, v_next)`.
- **`differential(u, c)`** — Raw acceleration term `c² ∇²u` for use with custom integrators like `phi.physics.integrate.rk4`.

All functions support:
- Constant or spatially varying wave speed `c` (as float, Tensor, or Field)
- Optional source term `f`
- Any Field type supported by `phi.field.laplace`

### `demos/wave_equation.py`
Demonstrates a 2D Gaussian pulse propagating on a 128×128 grid using the leapfrog scheme.

## Design Decisions

- **Leapfrog as primary scheme**: Natural choice for the wave equation — it is time-reversible and exactly conserves a discrete energy, unlike forward Euler or RK4. Widely used in computational acoustics and seismology.
- **Function-based API**: Matches the existing patterns in `phi.physics.diffuse` and `phi.physics.advect` rather than introducing class-based abstractions.
- **No new dependencies**: Uses only existing `phi.field.laplace` and standard Field operations.

## Motivation

The wave equation is one of the three fundamental linear PDEs (along with diffusion and Laplace's equation). Having native support enables:
- Acoustics simulations
- Seismology / elastic wave propagation
- Electromagnetic wave modeling
- Neural operator training data generation for wave-type problems
- Teaching / tutorials on hyperbolic PDEs with PhiFlow