### PR TITLE
[field] Resample in Field._op2 when sampling differs (fix StaggeredGrid * CenteredGrid)

### DIFF
--- a/phi/field/_field.py
+++ b/phi/field/_field.py
@@ -789,7 +789,7 @@ class Field(metaclass=_FieldType):
         if isinstance(other, Geometry):
             raise ValueError(f"Cannot combine {self.__class__.__name__} with a Geometry, got {type(other)}")
         if isinstance(other, Field):
-            if self.geometry == other.geometry:
+            if self.geometry == other.geometry and self.sampled_at == other.sampled_at:
                 values = operator(self.values, other.values)
                 extrapolation_ = operator(self.boundary, other.extrapolation)
                 return Field(self.geometry, values, extrapolation_)

--- a/tests/commit/field/test__field.py
+++ b/tests/commit/field/test__field.py
@@ -103,3 +103,19 @@ class TestField(TestCase):
         grid = v.to_grid(x=10, y=10)
         self.assertEqual(resolution.with_sizes(10), grid.resolution)
         self.assertEqual(grid.bounds, mesh.bounds)
+
+    def test_op2_different_sampling_resamples(self):
+        # A StaggeredGrid and a CenteredGrid share the same geometry but sample at different
+        # locations (faces vs. cell centers). Binary operations between them must resample one
+        # onto the other instead of multiplying the raw (differently-shaped) value tensors.
+        # Regression test for #210 (StaggeredGrid * CenteredGrid).
+        velocity = StaggeredGrid(1, 0, x=8, y=8)
+        mask = CenteredGrid(2, 0, x=8, y=8)
+        product = velocity * mask
+        self.assertEqual('face', product.sampled_at)
+        math.assert_close(2, product.values)  # 1 (face) * 2 (mask resampled to faces)
+        # A zero mask must zero out the velocity field everywhere.
+        math.assert_close(0, (velocity * CenteredGrid(0, 0, x=8, y=8)).values)
+        # Same-sampling operations must still take the fast path and stay correct.
+        math.assert_close(4, (mask * mask).values)
+        self.assertEqual('face', (velocity * velocity).sampled_at)


### PR DESCRIPTION
## Summary

`Field._op2` (used by all `Field` arithmetic — `*`, `+`, `-`, `/`, comparisons) takes a fast path that multiplies the raw value tensors whenever `self.geometry == other.geometry`:

```python
if self.geometry == other.geometry:
    values = operator(self.values, other.values)
    ...
```

A `StaggeredGrid` and a `CenteredGrid` over the same domain **share the same geometry but sample at different locations** (cell faces vs. cell centers — `sampled_at` is `'face'` vs `'center'`). So this fast path fires for `StaggeredGrid * CenteredGrid` and multiplies tensors of incompatible spatial shapes, raising:

```
phiml.math._shape.IncompatibleShapes: Cannot merge shapes ((xˢ=64, yˢ=64), (xˢ=63, yˢ=64)) ...
```

(reported as `AttributeError: 'Dim' object has no attribute 'shape'` on older phiml). This breaks the very common operation of applying a scalar solid/fluid mask to a velocity field (`velocity * mask`) in immersed-boundary Navier–Stokes workflows.

Fixes #210.

## Fix

Require matching `sampled_at` for the fast path, so fields sampled at different locations correctly fall through to the **existing** resampling branch (which already resamples `other` onto `self.geometry, self.sampled_at`):

```python
if self.geometry == other.geometry and self.sampled_at == other.sampled_at:
```

One line; no behavior change for fields that already share the same sampling.

## Verification

- `StaggeredGrid * CenteredGrid` now resamples and returns a correct staggered field: `StaggeredGrid(1) * CenteredGrid(2)` is `2` everywhere, and a zero mask zeroes out the velocity. Both operand orders and `+ - /` behave consistently.
- Added regression test `test_op2_different_sampling_resamples` in `tests/commit/field/test__field.py` — it fails before this change and passes after.
- `tests/commit/field/` and `tests/commit/physics/` pass (107 tests, including `test_fluid.py`), no regressions.
